### PR TITLE
Default authentication, authentication without popup possible, split domain, restrict to authorized domains

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -16,13 +16,17 @@ class PluginSinglesignonToolbox {
 
       $url .= "/provider/".$row['id'];
 
-      if (!empty($query) && $row['type'] != 'google') {
-         $url .= "/q/" . base64_encode(http_build_query($query));
-      } else if (!empty($query) && $row['type'] == 'google') {
+      if (!empty($query)) {
          $_SESSION['redirect'] = $query['redirect'];
       }
 
       return $url;
+   }
+
+   public static function isDefault($row, $query = []) {
+
+      if ($row['is_default'] == 1) return true;
+      return false;
    }
 
    public static function getCallbackParameters($name = null) {
@@ -129,7 +133,9 @@ class PluginSinglesignonToolbox {
    }
 
    public static function renderButton($url, $data, $class = 'oauth-login') {
-      $btn = '<span><a href="' . $url . '" class="singlesignon vsubmit ' . $class . '"';
+      $popupClass = "";
+      if (isset($data['popup']) && $data['popup'] == 1) $popupClass = "popup";
+      $btn = '<span><a href="' . $url . '" class="singlesignon vsubmit ' . $class . ' ' . $popupClass . '"';
 
       $style = '';
       if ((isset($data['bgcolor']) && $data['bgcolor'])) {
@@ -147,7 +153,7 @@ class PluginSinglesignonToolbox {
          $btn .= Html::image(
             static::getPictureUrl($data['picture']),
             [
-               'style' => 'max-height: 20px;',
+               'style' => 'max-height: 20px;margin-right: 4px',
             ]
          );
          $btn .= ' ';

--- a/locales/fr_FR.po
+++ b/locales/fr_FR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: singlesignon 1.3.1\n"
 "Report-Msgid-Bugs-To: https://github.com/edgardmessias/glpi-singlesignon/issues\n"
 "POT-Creation-Date: 2021-03-17 09:30-0300\n"
-"PO-Revision-Date: 2022-03-23 14:36+0100\n"
+"PO-Revision-Date: 2022-03-23 14:35+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en_GB\n"
@@ -31,7 +31,8 @@ msgid "Provider not active."
 msgstr "Provider not active."
 
 #: front/provider.form.php:61 front/provider.form.php:63 front/provider.php:8
-#: front/provider.php:10 inc/preference.class.php:64 inc/provider.class.php:57 setup.php:40
+#: front/provider.php:10 inc/preference.class.php:64 inc/provider.class.php:57
+#: setup.php:40
 msgid "Single Sign-on"
 msgstr "Single Sign-on"
 
@@ -151,7 +152,7 @@ msgstr "LinkdeIn"
 #: inc/toolbox.class.php:154
 #, php-format
 msgid "Login with %s"
-msgstr "Login with %s"
+msgstr "Se connecter avec %s"
 
 #: setup.php:8
 #, php-format
@@ -164,16 +165,16 @@ msgstr "This plugin requires GLPI >= 0.85"
 
 #: inc/provider.class.php:141
 msgid "IsDefault"
-msgstr "Default Authentication"
+msgstr "Authentification par défaut"
 
 msgid "PopupAuth"
-msgstr "Authentication through a Pop-up"
+msgstr "Authentification via Pop-up"
 
 msgid "SplitDomain"
-msgstr "Do not take into account the domain for the matching with the GLPI user identifier"
+msgstr "Ne pas prendre en compte le domaine pour la correspondance de l'identifiant GLPI"
 
 msgid "AuthorizedDomains"
-msgstr "Authorized domains"
+msgstr "Domaines autorisés"
 
 msgid "AuthorizedDomainsTooltip"
-msgstr "Allowed domains separated by ','. Empty : all domains are allowed"
+msgstr "Domaines autorisés séparés par des ','. Vide : tous les domaines sont autorisés"

--- a/locales/singlesignon.pot
+++ b/locales/singlesignon.pot
@@ -162,3 +162,19 @@ msgstr ""
 #: setup.php:57
 msgid "This plugin requires GLPI >= 0.85"
 msgstr ""
+
+#: inc/provider.class.php:141
+msgid "IsDefault"
+msgstr ""
+
+msgid "PopupAuth"
+msgstr ""
+
+msgid "SplitDomain"
+msgstr ""
+
+msgid "AuthorizedDomains"
+msgstr ""
+
+msgid "AuthorizedDomainsTooltip"
+msgstr ""

--- a/providers.json
+++ b/providers.json
@@ -1,4 +1,10 @@
 {
+   "azure": {
+      "url_authorize": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+      "url_access_token": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      "url_resource_owner_details": "https://graph.microsoft.com/v1.0/me",
+      "scope": "User.Read"
+   },
    "facebook": {
       "url_authorize": "https://www.facebook.com/v9.0/dialog/oauth",
       "url_access_token": "https://graph.facebook.com/v9.0/oauth/access_token",

--- a/setup.php
+++ b/setup.php
@@ -1,6 +1,6 @@
 <?php
 
-define('PLUGIN_SINGLESIGNON_VERSION', '1.3.1');
+define('PLUGIN_SINGLESIGNON_VERSION', '1.3.2');
 
 $folder = basename(dirname(__FILE__));
 


### PR DESCRIPTION
Hi,

I've made a few changes in order to match my needs : 

- Added Azure AD provider in providers.json file
- Added a configuration 'is_default' to specify that we want the provider to automatically try to login by default : if not authenticated, glpi will automatically try to authenticate you with the first provider that has the configuration is_default: true. If there is none, it will act as before, with the different authentication methods screen.
- Added a configuration 'popup' to specify that we want the provider to login through a popup (current behavior) or in the current window.
- Added a configuration 'split_domain' to specify that we want to match the provider login/mail with the glpi user identifier without taking into account the domain name from the provider login/name. IE: toto@outlook.com (provider being outlook) will match with the glpi user with the name "toto". If this configuration is false, it will act as before.
- Added configuration 'authorized_domains' to restrict to authorized domain. IE: if authorized domains is '@outlook.com', and split_domain is true, glpi has a user with logon name "toto" ; toto@outlook.com will be able to login as toto, but toto@hotmail.com won't be able to sign in. Note: I take outlook and hotmail domains as an example, but concretly I use azure authentication where every tenant can connect with, so I wanted to be able to restrict which tenant can connect. Also, I want in a next version to be able to automatically create the user if not present (thus the need to restrict domains)
