### PR TITLE
Add support for DexIDP w/ SAML

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -231,6 +231,8 @@ function plugin_singlesignon_install() {
                   `url_access_token`           varchar(255) COLLATE utf8_unicode_ci NULL,
                   `url_resource_owner_details` varchar(255) COLLATE utf8_unicode_ci NULL,
                   `is_active`                  tinyint(1) NOT NULL DEFAULT '0',
+                  `use_email_for_login`        tinyint(1) NOT NULL DEFAULT '0',
+                  `split_name`                 tinyint(1) NOT NULL DEFAULT '0',
                   `is_deleted`                 tinyint(1) NOT NULL default '0',
                   `comment`                    text COLLATE utf8_unicode_ci,
                   `date_mod`                   datetime DEFAULT NULL,
@@ -262,6 +264,16 @@ function plugin_singlesignon_install() {
       $result = $DB->query($query) or die($DB->error());
       if ($DB->numrows($result) != 1) {
          $DB->query("ALTER TABLE glpi_plugin_singlesignon_providers ADD authorized_domains varchar(255) COLLATE utf8_unicode_ci NULL") or die($DB->error());
+      }
+      $query = "SHOW COLUMNS FROM glpi_plugin_singlesignon_providers LIKE 'use_email_for_login'";
+      $result = $DB->query($query) or die($DB->error());
+      if ($DB->numrows($result) != 1) {
+         $DB->query("ALTER TABLE glpi_plugin_singlesignon_providers ADD use_email_for_login tinyint(1) NOT NULL DEFAULT '0'") or die($DB->error());
+      }
+      $query = "SHOW COLUMNS FROM glpi_plugin_singlesignon_providers LIKE 'split_name'";
+      $result = $DB->query($query) or die($DB->error());
+      if ($DB->numrows($result) != 1) {
+         $DB->query("ALTER TABLE glpi_plugin_singlesignon_providers ADD split_name tinyint(1) NOT NULL DEFAULT '0'") or die($DB->error());
       }
    }
 

--- a/inc/provider.class.php
+++ b/inc/provider.class.php
@@ -185,6 +185,14 @@ class PluginSinglesignonProvider extends CommonDBTM {
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
+      echo "<td>" . __sso("Use Email as Login") . "<td>";
+      Dropdown::showYesNo("use_email_for_login", $this->fields["use_email_for_login"]);
+      echo "</td>";
+      echo "<td>" . __sso('Split Name') . "<td>";
+      Dropdown::showYesNo("split_name", $this->fields["split_name"]);
+      echo "</td>";
+
+      echo "<tr class='tab_bg_1'>";
       echo "<th colspan='4'>" . __('Personalization') . "</th>";
       echo "</tr>\n";
 
@@ -517,6 +525,24 @@ class PluginSinglesignonProvider extends CommonDBTM {
          'table' => $this->getTable(),
          'field' => 'is_active',
          'name' => __('Active'),
+         'searchtype' => 'equals',
+         'datatype' => 'bool',
+      ];
+
+      $tab[] = [
+         'id' => 11,
+         'table' => $this->getTable(),
+         'field' => 'use_email_for_login',
+         'name' => __('Use email field for login'),
+         'searchtype' => 'equals',
+         'datatype' => 'bool',
+      ];
+
+      $tab[] = [
+         'id' => 12,
+         'table' => $this->getTable(),
+         'field' => 'split_name',
+         'name' => __('Split name field for First & Last Name'),
          'searchtype' => 'equals',
          'datatype' => 'bool',
       ];
@@ -1132,34 +1158,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
          $authorizedDomains = explode(',', $authorizedDomainsString);
       }
 
-      $login = false;
-      $login_fields = ['userPrincipalName', 'login', 'username', 'id', 'name', 'displayName'];
-
-      foreach ($login_fields as $field) {
-         if (isset($resource_array[$field]) && is_string($resource_array[$field])) {
-            $login = $resource_array[$field];
-            $isAuthorized = empty($authorizedDomains);
-            foreach ($authorizedDomains as $authorizedDomain) {
-               if (preg_match("/{$authorizedDomain}$/i", $login)) {
-                  $isAuthorized = true;
-               }
-            }
-
-            if (!$isAuthorized) {
-               return false;
-            }
-            if ($split) {
-               $loginSplit = explode("@", $login);
-               $login = $loginSplit[0];
-            }
-            break;
-         }
-      }
-
-      if ($login && $user->getFromDBbyName($login)) {
-         return $user;
-      }
-
+      // check email first
       $email = false;
       $email_fields = ['email', 'e-mail', 'email-address', 'mail'];
 
@@ -1183,6 +1182,40 @@ class PluginSinglesignonProvider extends CommonDBTM {
          }
       }
 
+      $login = false;
+      $use_email = $this->fields['use_email_for_login'];
+      if ($email && $use_email){
+         $login = $email;
+      }
+      else{
+         $login_fields = ['userPrincipalName', 'login', 'username', 'id', 'name', 'displayName'];
+
+         foreach ($login_fields as $field) {
+            if (isset($resource_array[$field]) && is_string($resource_array[$field])) {
+               $login = $resource_array[$field];
+               $isAuthorized = empty($authorizedDomains);
+               foreach ($authorizedDomains as $authorizedDomain) {
+                  if (preg_match("/{$authorizedDomain}$/i", $login)) {
+                     $isAuthorized = true;
+                  }
+               }
+
+               if (!$isAuthorized) {
+                  return false;
+               }
+               if ($split) {
+                  $loginSplit = explode("@", $login);
+                  $login = $loginSplit[0];
+               }
+               break;
+            }
+         }
+      }
+
+      if ($login && $user->getFromDBbyName($login)) {
+         return $user;
+      }
+
       $default_condition = '';
 
       if (version_compare(GLPI_VERSION, '9.3', '>=')) {
@@ -1202,38 +1235,28 @@ class PluginSinglesignonProvider extends CommonDBTM {
       // If the user does not exist in the database and the provider is generic (Ex: azure ad without common tenant)
       if (static::getClientType() == "generic" && !$bOk) {
          try {
-            // Generates an api token and a personal token
+            // Generates an api token and a personal token... probably not necessary
             $tokenAPI = base_convert(hash('sha256', time() . mt_rand()), 16, 36);
             $tokenPersonnel = base_convert(hash('sha256', time() . mt_rand()), 16, 36);
 
-            $userPost['name'] = "";
-            $userPost['realname']  = "";
-            $userPost['firstname'] = "";
-            foreach ($login_fields as $field) {
-               if (isset($resource_array[$field]) && is_string($resource_array[$field])) {
-                  $userPost['name'] = $resource_array[$field];
-                  $userPost['realname'] = preg_split('/ /', $resource_array['displayName'])[1];
-                  $userPost['firstname'] = preg_split('/ /', $resource_array['displayName'])[0];
-                  break;
-               }
+            $splitname = $this->fields['split_name'];
+            $firstLastArray = ($splitname) ? preg_split('/ /', $resource_array['name'], 2) : preg_split('/ /', $resource_array['displayName'], 2);
+
+            $userPost = [
+               'name' => $login,
+               'add' => 1,
+               'realname' => $firstLastArray[1],
+               'firstname' => $firstLastArray[0],
+               'api_token' => $tokenAPI,
+               'personal_token' => $tokenPersonnel,
+               'is_active' => 1
+            ];
+
+            if($email){
+               $userPost['_useremails'][-1] = $email;
             }
 
-            $userPost['_useremails'][-1] = "";
-            foreach ($email_fields as $field) {
-               if (isset($resource_array[$field]) && is_string($resource_array[$field])) {
-                  $userPost['_useremails'][-1] = $resource_array[$field];
-                  break;
-               }
-            }
-
-            // $userPost['name'] = $resource_array['displayName'];
-            // $userPost['realname'] = preg_split('/ /', $resource_array['displayName'])[1];
-            // $userPost['_useremails'][-1] = $resource_array['mail'];
-            // $userPost['firstname'] = preg_split('/ /', $resource_array['displayName'])[0];
-            $userPost['api_token'] = $tokenAPI;
-            $userPost['personal_token'] = $tokenPersonnel;
-            $userPost['is_active'] = 1;
-            $userPost['add'] = "1";
+            //$user->check(-1, CREATE, $userPost);
             $newID = $user->add($userPost);
 
             // var_dump($newID);

--- a/inc/provider.class.php
+++ b/inc/provider.class.php
@@ -1184,10 +1184,9 @@ class PluginSinglesignonProvider extends CommonDBTM {
 
       $login = false;
       $use_email = $this->fields['use_email_for_login'];
-      if ($email && $use_email){
+      if ($email && $use_email) {
          $login = $email;
-      }
-      else{
+      } else {
          $login_fields = ['userPrincipalName', 'login', 'username', 'id', 'name', 'displayName'];
 
          foreach ($login_fields as $field) {
@@ -1252,7 +1251,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
                'is_active' => 1
             ];
 
-            if($email){
+            if ($email) {
                $userPost['_useremails'][-1] = $email;
             }
 

--- a/setup.php
+++ b/setup.php
@@ -25,7 +25,7 @@
  * ---------------------------------------------------------------------
  */
 
-define('PLUGIN_SINGLESIGNON_VERSION', '1.3.3');
+define('PLUGIN_SINGLESIGNON_VERSION', '1.3.4');
 
 $folder = basename(dirname(__FILE__));
 


### PR DESCRIPTION
We use [DexIDP](https://github.com/dexidp/dex) with SAML (ADFS) to connect with oAuth2 / OpenID Connect applications because Microsoft has a custom version of OpenID Connect built into ADFS that almost nothing supports.

Because of the ADFS -> DexIDP setup, we are limited in the values we can send from Dex to your plugin. These shortcomings may exist in other "generic" providers as well but I'm unaware.

Dex is essentially sending only 2 usable values: `name` and `email`. Your plugin will use the `name` field as the GLPI username, however in this situation `name` comes across more as a displayName, which means it looks like "John Doe" - GLPI cannot use spaces in the username. However, my email field is unique, so that is appropriate to use as a login field.

Additionally, because Dex is not sending over a separate displayName or first_name / last_name attributes, the only way to get those is from the `name` attribute.

To solve both of those problems, I created options to use the email address as the username when creating a new user, and I added an option to split the name field into the first and last name.

This PR does not change any existing functionality, just adds new functionality to satisfy new use cases.

![image](https://user-images.githubusercontent.com/33401067/211643253-13a77c7c-c60f-4303-ad4d-0b098ec4e245.png)
