### PR TITLE
Update toolbox.class.php

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -39,7 +39,10 @@ class PluginSinglesignonToolbox {
 
       $url = $CFG_GLPI['root_doc'] . '/plugins/singlesignon/front/callback.php';
 
-      $url .= "/provider/".$row['id'];
+      if(is_int($row))
+         $url .= "/provider/".$row;
+      else
+         $url .= "/provider/".$row['id'];
 
       if (!empty($query)) {
          $_SESSION['redirect'] = $query['redirect'];


### PR DESCRIPTION
I can see that getCallbackUrl is called with int as first variable, but some chat says there is issue with array, $ID was changed to $row['id'] ... Many calls is done with int anyway, so we check if value is int or array before printing callback URL.