### PR TITLE
Fix provider ID and removed /test/1 in redirect_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Single sign-on (SSO) is a property of access control of multiple related, yet in
  * Instagram - https://www.instagram.com/developer/authentication/
  * LinkedIn - https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin/context
  * Generic - Allow to define custom URLs
+ * Zitadel - use _Generic_ and see parameters in [Generic Examples - Zitadel](generic_examples/zitadel.md)
 
 # Screenshots
 

--- a/generic_examples/zitadel.md
+++ b/generic_examples/zitadel.md
@@ -1,0 +1,29 @@
+- Go to Zitadel and login as admin
+- Create a new Project, name for example: glpi
+- Create a new Application in this new project, name for example: glpi
+  - Type of application: WEB
+  - Authentication Method: CODE
+  - Redirect URIs: empty, will be set later
+  - Create
+  - Save Client-ID and Client-Secret, we need it later
+- Go to GLPI and login as a Super-Admin
+- Install and activate the plugin
+- Go to the plugin settings
+- Create your first Single Sign-on Provider with the following options
+  - Name: choose one you like
+  - Client ID: the previous saved Client-ID from Zitadel
+  - client Secret: the previous saved Client-Secret from Zitadel
+  - Scope: openid email profile
+  - Authorize URL: https://zitadel.example.com/oauth/v2/authorize
+  - Access Token URL: https://zitadel.example.com/oauth/v2/token
+  - Resource Owner Details URL: https://zitadel.example.com/oidc/v1/userinfo
+  - SplitDomain: Yes
+  - Split Name: Yes
+  - Save Settings
+- Copy the Callback URL and go back to Zitadel
+- Open the project and the application, then go to Redirect Settings
+- Paste the URL in Redirect URIs, click on the plus and save the settings
+- Go back to GLPI and open the provider in the plugins settings again, now press Test Single Sign-on
+- A Pop-Up should open and close after a few seconds and the side reloads
+- Your current account should be linked now to your current Zitadel Account
+- All users from Zitadel can login into glpi and will be created there automatically

--- a/inc/provider.class.php
+++ b/inc/provider.class.php
@@ -290,7 +290,8 @@ class PluginSinglesignonProvider extends CommonDBTM {
          $("[name=test_singlesignon]").on("click", function (e) {
             e.preventDefault();
 
-            var url   = $("#singlesignon_callbackurl").attr("data-url") + "/test/1";
+            // Im not sure why /test/1 is added here, I got a problem with the redirect_uri because its added after /provider/id
+            var url   = $("#singlesignon_callbackurl").attr("data-url"); // + "/test/1";
             var left  = ($(window).width()/2)-(600/2);
             var top   = ($(window).height()/2)-(800/2);
             var newWindow = window.open(url, "singlesignon", "width=600,height=800,left=" + left + ",top=" + top);

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -39,7 +39,7 @@ class PluginSinglesignonToolbox {
 
       $url = $CFG_GLPI['root_doc'] . '/plugins/singlesignon/front/callback.php';
 
-      $url .= "/provider/".$row['id'];
+      $url .= "/provider/".$row;
 
       if (!empty($query)) {
          $_SESSION['redirect'] = $query['redirect'];


### PR DESCRIPTION
I could not set up SSO with Zitadel so i needed to change the 2 lines.
After the changes I was able to SSO with Zitadel.
For testing I deleted the plugin, removed the 2 tables, inserted my changed plugin, installed it, setup everything up again and logged in. Works fine for me.

For the change in toolbox.class.php see this issue: #83 

For the change in provider.class.php see this issue: #26 