### PR TITLE
Fix translation, fix reinstall table already exists, fix deprecated datetime, Add german translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ Single sign-on (SSO) is a property of access control of multiple related, yet in
  * Generic - Allow to define custom URLs
  * Zitadel - use _Generic_ and see parameters in [Generic Examples - Zitadel](generic_examples/zitadel.md)
 
+# Adding translations
+If your preferred language is missing. You can add your own translation with the following steps:
+ * Go to the plugin folder
+ * Switch to the folder locales
+ * Copy one of the already existing .po files
+ * Rename it into the correct notation of your language
+ * Edit the file, edit msgstr to change the translation, do not touch the msgid
+ * Edit the header especially the "Language: "
+ * When the file is ready, then you need to compile it with: msgfmt -o filename.mo filename.po
+ * If msgfmt is not found, install the package gettext (apt install -y gettext)
+ * If you edit a previous translation, you may need to update the translation cache: go to Setup - General - Performance, enable Debug mode, clear translation cache
+
 # Screenshots
 
 ![image 1](./screenshots/image_1.png)

--- a/hook.php
+++ b/hook.php
@@ -235,8 +235,8 @@ function plugin_singlesignon_install() {
                   `split_name`                 tinyint(1) NOT NULL DEFAULT '0',
                   `is_deleted`                 tinyint(1) NOT NULL default '0',
                   `comment`                    text COLLATE utf8_unicode_ci,
-                  `date_mod`                   datetime DEFAULT NULL,
-                  `date_creation`              datetime DEFAULT NULL,
+                  `date_mod`                   timestamp NULL DEFAULT NULL,
+                  `date_creation`              timestamp NULL DEFAULT NULL,
                   PRIMARY KEY (`id`),
                   KEY `date_mod` (`date_mod`),
                   KEY `date_creation` (`date_creation`)
@@ -290,14 +290,14 @@ function plugin_singlesignon_install() {
       $DB->query("INSERT INTO `glpi_displaypreferences` VALUES (NULL,'PluginSinglesignonProvider','10','6','0');");
    }
 
-   if (version_compare($currentVersion, "1.2.0", '<')) {
+   if (!sso_TableExists("glpi_plugin_singlesignon_providers_users") && version_compare($currentVersion, "1.2.0", '<')) {
       $query = "ALTER TABLE `glpi_plugin_singlesignon_providers`
                 ADD `picture` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                 ADD `bgcolor` varchar(7) DEFAULT NULL,
                 ADD `color` varchar(7) DEFAULT NULL";
       $DB->query($query) or die("error adding picture column " . $DB->error());
    }
-   if (version_compare($currentVersion, "1.3.0", '<')) {
+   if (!sso_TableExists("glpi_plugin_singlesignon_providers_users") && version_compare($currentVersion, "1.3.0", '<')) {
       $query = "CREATE TABLE `glpi_plugin_singlesignon_providers_users` (
          `id` int(11) NOT NULL AUTO_INCREMENT,
          `plugin_singlesignon_providers_id` int(11) NOT NULL DEFAULT '0',

--- a/locales/de_DE.po
+++ b/locales/de_DE.po
@@ -1,0 +1,195 @@
+# German translations for singlesignon package.
+# Copyright (C) 2022 THE singlesignon'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the singlesignon package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: singlesignon 1.3.2\n"
+"Report-Msgid-Bugs-To: https://github.com/edgardmessias/glpi-singlesignon/"
+"issues\n"
+"POT-Creation-Date: 2024-04-06 10:00-0300\n"
+"PO-Revision-Date: 2024-04-06 10:00-0300\n"
+"Last-Translator: invisiblemarcel\n"
+"Language-Team: none\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: front/callback.php:15
+msgid "Provider not defined."
+msgstr "Provider nicht definiert."
+
+#: front/callback.php:21
+msgid "Provider not found."
+msgstr "Provider nicht gefunden."
+
+#: front/callback.php:25
+msgid "Provider not active."
+msgstr "Provider nicht aktiv."
+
+#: front/provider.form.php:61 front/provider.form.php:63 front/provider.php:8
+#: front/provider.php:10 inc/preference.class.php:64 inc/provider.class.php:59
+#: setup.php:40
+msgid "Single Sign-on"
+msgstr "Single Sign-on"
+
+#: inc/preference.class.php:147 inc/provider.class.php:52
+msgid "Single Sign-on Provider"
+msgstr "Single Sign-on Provider"
+
+#: inc/preference.class.php:172
+msgid "Linked accounts"
+msgstr "Verlinkte Accounts"
+
+#: inc/provider.class.php:100
+msgid "SSO Type"
+msgstr "SSO Typ"
+
+#: inc/provider.class.php:108 inc/provider.class.php:445
+msgid "Client ID"
+msgstr "Client ID"
+
+#: inc/provider.class.php:110 inc/provider.class.php:453
+msgid "Client Secret"
+msgstr "Client Secret"
+
+#: inc/provider.class.php:121 inc/provider.class.php:461
+msgid "Scope"
+msgstr "Scope"
+
+#: inc/provider.class.php:123 inc/provider.class.php:469
+msgid "Extra Options"
+msgstr "Weitere Optionen"
+
+#: inc/provider.class.php:128 inc/provider.class.php:477
+msgid "Authorize URL"
+msgstr "URL Autorisierung"
+
+#: inc/provider.class.php:133 inc/provider.class.php:485
+msgid "Access Token URL"
+msgstr "URL Access Token"
+
+#: inc/provider.class.php:138 inc/provider.class.php:493
+msgid "Resource Owner Details URL"
+msgstr "URL Benutzerinfornmationen"
+
+#: inc/provider.class.php:145
+msgid "PopupAuth"
+msgstr "PopupAuth"
+
+#: inc/provider.class.php:151
+msgid "SplitDomain"
+msgstr "Domäne abtrennen"
+
+#: inc/provider.class.php:168
+msgid "IsDefault"
+msgstr "Ist Standard"
+
+#: inc/provider.class.php:188
+msgid "Use Email as Login"
+msgstr "E-Mail als Login benutzen"
+
+#: inc/provider.class.php:191
+msgid "Split Name"
+msgstr "Name abtrennen"
+
+#: inc/provider.class.php:155
+msgid "AuthorizedDomains"
+msgstr "Erlaubte Domänen"
+
+#: inc/provider.class.php:157
+msgid "AuthorizedDomainsTooltip"
+msgstr "Erlaubte Domänen Hinweis"
+
+#: inc/provider.class.php:246
+msgid "Callback URL"
+msgstr "Callback URL"
+
+#: inc/provider.class.php:250
+msgid "Test Single Sign-on"
+msgstr "Teste Single Sign-on"
+
+#: inc/provider.class.php:308
+msgid "A Name is required"
+msgstr "Es wird ein Name benötigt."
+
+#: inc/provider.class.php:314
+#, php-format
+msgid "The \"%s\" is a Invalid type"
+msgstr "Der Typ \"%s\" ist nicht gültig"
+
+#: inc/provider.class.php:318
+msgid "A Client ID is required"
+msgstr "Eine Client ID ist notwendig"
+
+#: inc/provider.class.php:322
+msgid "A Client Secret is required"
+msgstr "Ein Client Secret ist notwendig"
+
+#: inc/provider.class.php:327
+msgid "An Authorize URL is required"
+msgstr "Eine Autorisierungs URL ist notwendig"
+
+#: inc/provider.class.php:329
+msgid "The Authorize URL is invalid"
+msgstr "Die Autorisierungs URL ist nicht gültig"
+
+#: inc/provider.class.php:333
+msgid "An Access Token URL is required"
+msgstr "Eine Access Token URL ist notwendig"
+
+#: inc/provider.class.php:335
+msgid "The Access Token URL is invalid"
+msgstr "Die Access Token URL ist nicht gültig"
+
+#: inc/provider.class.php:339
+msgid "A Resource Owner Details URL is required"
+msgstr "Eine Benutzerinfornmationen URL ist notwendig"
+
+#: inc/provider.class.php:341
+msgid "The Resource Owner Details URL is invalid"
+msgstr "Die Benutzerinfornmationen URL ist nicht gültig"
+
+#: inc/provider.class.php:552
+msgid "Generic"
+msgstr "Generisch"
+
+#: inc/provider.class.php:553
+msgid "Azure"
+msgstr "Azure"
+
+#: inc/provider.class.php:554
+msgid "Facebook"
+msgstr "Facebook"
+
+#: inc/provider.class.php:555
+msgid "GitHub"
+msgstr "GitHub"
+
+#: inc/provider.class.php:556
+msgid "Google"
+msgstr "Google"
+
+#: inc/provider.class.php:557
+msgid "Instagram"
+msgstr "Instagram"
+
+#: inc/provider.class.php:558
+msgid "LinkdeIn"
+msgstr "LinkdeIn"
+
+#: inc/toolbox.class.php:166
+#, php-format
+msgid "Login with %s"
+msgstr "Login mit %s"
+
+#: setup.php:8
+#, php-format
+msgid "Please, rename the plugin folder \"%s\" to \"singlesignon\""
+msgstr "Bitte benenne das Plugin Verzeichnis von \"%s\" in \"singlesignon\" um."
+
+#: setup.php:57
+msgid "This plugin requires GLPI >= 0.85"
+msgstr "Das Plugin benötigt mindestens GLPI Version 0.85"

--- a/plugin.xml
+++ b/plugin.xml
@@ -95,6 +95,7 @@ Single sign-on (SSO) is a property of access control of multiple related, yet in
     <langs>
         <lang>en_GB</lang>
         <lang>pt_BR</lang>
+	<lang>de_DE</lang>
     </langs>
     <license><![CDATA[GPL v2+]]></license>
     <tags>


### PR DESCRIPTION
These changes are pulled separately because of the major changes.
- I always needed to drop the tables manually when I uninstalled the plugin, so I added 2 checks to avoid that.
- It was not enough to copy a .po File for translation, I needed to compile them so I add a note in the Readme and compiled all lang files and added them to the repo (I know binary files in git are crap but it's much easier for the users)
- German translation added
- The table column type datetime is deprecated so I changed it to timestamp, before you always needed to run a command displayed in the UI to migrate it 