### PR TITLE
Improve error reporting to end user on login failed

### DIFF
--- a/inc/provider.class.php
+++ b/inc/provider.class.php
@@ -1025,6 +1025,14 @@ class PluginSinglesignonProvider extends CommonDBTM {
          if ($this->debug) {
             print_r($data);
          }
+         if (isset($data['error_description'])) {
+            echo '<style>#page .center small { font-weight: normal; }</style>
+            <script type="text/javascript">
+            window.onload = function() {
+               $("#page .center").append("<br><br><small>' . $data['error_description'] . '</small>");
+            };
+            </script>';
+         }
          if (!isset($data['access_token'])) {
             return false;
          }


### PR DESCRIPTION
PT-BR:

Boa noite Edgar, tudo bem?
Parabéns pelo seu plug-in! Recentemente, tentei fazer login no GLPI usando minhas credenciais do Azure e não consegui, então ao alterar o valor da variável ``debug`` no arquivo ``provider.class.php`` do seu plug-in, descobri o porquê: minha //secret key// estava expirada. Atualmente, o plug-in não reporta erros do provedor SSO ao usuário, este PR adiciona essa capacidade. Print da adição de funcionalidade abaixo:

![image](https://github.com/user-attachments/assets/7fc8cc78-4df2-4778-9acd-5711745a46c7)

EN: This PR shows SSO errors from provider to the end user if login fails.