### PR TITLE
Add API token date

### DIFF
--- a/inc/provider.class.php
+++ b/inc/provider.class.php
@@ -1269,6 +1269,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
             //'picture' => $resource_array['picture'] ?? '',
             'picture' => $resource_array['picture'],
             'api_token' => $tokenAPI,
+            'api_token_date' => date("Y-m-d H:i:s"),
             'personal_token' => $tokenPersonnel,
             'is_active' => 1
          ];
@@ -1293,6 +1294,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
                'realname' => $firstLastArray[1],
                'firstname' => $firstLastArray[0],
                'api_token' => $tokenAPI,
+               'api_token_date' => date("Y-m-d H:i:s"),
                'personal_token' => $tokenPersonnel,
                'is_active' => 1
             ];


### PR DESCRIPTION
PT-BR:

Boa tarde, Edgar!
Ao acessar a página "Minhas configurações" do usuário, é exibido o token de API gerado porém não exibe sua data de criação (o campo "gerado em" fica vazio). Este PR adiciona a data e hora atual como data de criação do token do usuário.

EN:

Adds the generated API token date for automatically created users.
