### PR TITLE
Sync GLPI photo with Azure AD

### DIFF
--- a/inc/provider.class.php
+++ b/inc/provider.class.php
@@ -1461,7 +1461,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
          ]);
          if (!empty($img)) {
             /* if ($this->debug) {
-               print_r($content);
+            print_r($content);
             } */
 
             //prepare paths
@@ -1476,13 +1476,13 @@ class PluginSinglesignonProvider extends CommonDBTM {
             }
 
             //update picture if not exist or changed
-            if ( empty($user->fields["picture"])
+            if (empty($user->fields["picture"])
                || !file_exists($oldfile)
                || sha1_file($oldfile) !== sha1($img)
             ) {
 
                if (!is_dir(GLPI_PICTURE_DIR . "/$sub")) {
-                   mkdir(GLPI_PICTURE_DIR . "/$sub");
+                  mkdir(GLPI_PICTURE_DIR . "/$sub");
                }
 
                //save picture
@@ -1498,7 +1498,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
                $success = $user->updateInDB(['picture']);
                if ($this->debug) {
                   print_r(['id' => $user->getId(), 
-                           'picture' => "{$sub}/{$filename}.jpg", 
+                           'picture' => "{$sub}/{$filename}.jpg",
                            'success' => $success
                   ]);
                }
@@ -1514,11 +1514,11 @@ class PluginSinglesignonProvider extends CommonDBTM {
                   print_r("{$sub}/{$filename}.jpg");
                }
                return "{$sub}/{$filename}.jpg";
-           }
-           if ($this->debug) {
+            }
+            if ($this->debug) {
                print_r($user->fields["picture"]);
-           }
-           return $user->fields["picture"];
+            }
+            return $user->fields["picture"];
          }
       }
 

--- a/inc/provider.class.php
+++ b/inc/provider.class.php
@@ -1431,7 +1431,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
     *
     * @return string|boolean Filename to be stored in user picture field, false if no picture found
     */
-    public function syncOAuthPhoto($user) {
+   public function syncOAuthPhoto($user) {
       $token = $this->getAccessToken();
       if (!$token) {
          return false;
@@ -1449,7 +1449,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
          print_r("\nsyncOAuthPhoto:\n");
       }
 
-     //get picture content (base64) in Azure
+      //get picture content (base64) in Azure
       if (preg_match("/^(?:https?:\/\/)?(?:[^.]+\.)?graph\.microsoft\.com(\/.*)?$/", $url)) {
          array_push($headers, "Content-Type:image/jpeg; charset=utf-8");
 
@@ -1459,12 +1459,12 @@ class PluginSinglesignonProvider extends CommonDBTM {
             CURLOPT_SSL_VERIFYHOST => false,
             CURLOPT_SSL_VERIFYPEER => false,
          ]);
-         if(!empty($img)) {
+         if (!empty($img)) {
             /* if ($this->debug) {
                print_r($content);
             } */
 
-           //prepare paths
+            //prepare paths
             $filename  = uniqid($user->fields['id'] . '_');
             $sub       = substr($filename, -2); /* 2 hex digit */
             $file      = GLPI_PICTURE_DIR . "/{$sub}/{$filename}.jpg";
@@ -1475,22 +1475,22 @@ class PluginSinglesignonProvider extends CommonDBTM {
                $oldfile = null;
             }
 
-           //update picture if not exist or changed
-            if (
-               empty($user->fields["picture"])
+            //update picture if not exist or changed
+            if ( empty($user->fields["picture"])
                || !file_exists($oldfile)
                || sha1_file($oldfile) !== sha1($img)
             ) {
+
                if (!is_dir(GLPI_PICTURE_DIR . "/$sub")) {
                    mkdir(GLPI_PICTURE_DIR . "/$sub");
                }
 
-              //save picture
+               //save picture
                $outjpeg = fopen($file, 'wb');
                fwrite($outjpeg, $img);
                fclose($outjpeg);
 
-              //save thumbnail
+               //save thumbnail
                $thumb = GLPI_PICTURE_DIR . "/{$sub}/{$filename}_min.jpg";
                Toolbox::resizePicture($file, $thumb);
 

--- a/inc/provider.class.php
+++ b/inc/provider.class.php
@@ -1497,7 +1497,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
                $user->fields['picture'] = "{$sub}/{$filename}.jpg";
                $success = $user->updateInDB(['picture']);
                if ($this->debug) {
-                  print_r(['id' => $user->getId(), 
+                  print_r(['id' => $user->getId(),
                            'picture' => "{$sub}/{$filename}.jpg",
                            'success' => $success
                   ]);


### PR DESCRIPTION
PT-BR:

Boa noite, Edgar! Tudo bem? Espero que sim. =D
Adicionei uma nova função ao seu plug-in, que permite sincronizar a foto do usuário do GLPI com a foto usada no Azure AD (a mesma usada no Teams e outros aplicativos on-line da Microsoft). Ela usa uma lógica similar da função nativa ``syncLdapPhoto()`` do GLPI e só baixa a foto e atualiza ela no banco de dados do GLPI se ela foi alterada pelo usuário no Azure AD.

English:

This PR uses a similar approach to the native function ``syncLdapPhoto()`` from GLPI core to automatically sync the GLPI photo of the user with the one set on Azure AD.

Screenshot:

![image](https://github.com/user-attachments/assets/7eea3498-f731-4542-8923-bea8a93d0ef2)
