### PR TITLE
Improve Reverse Proxy and Plugin folder support

### DIFF
--- a/front/callback.php
+++ b/front/callback.php
@@ -56,7 +56,7 @@ $test = PluginSinglesignonToolbox::getCallbackParameters('test');
 
 if ($test) {
    $signon_provider->debug = true;
-   Html::nullHeader("Login", $CFG_GLPI["root_doc"] . '/index.php');
+   Html::nullHeader("Login", PluginSinglesignonToolbox::getBaseURL() . '/index.php');
    echo '<div class="left spaced">';
    echo '<pre>';
    echo "### BEGIN ###\n";
@@ -98,19 +98,19 @@ if ($user_id || $signon_provider->login()) {
 
    if ($_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
       if ($_SESSION['glpiactiveprofile']['create_ticket_on_login'] && empty($REDIRECT)) {
-         $url_redirect = $CFG_GLPI['root_doc'] . "/front/helpdesk.public.php?create_ticket=1";
+         $url_redirect = PluginSinglesignonToolbox::getBaseURL() . "/front/helpdesk.public.php?create_ticket=1";
       } else {
-         $url_redirect = $CFG_GLPI['root_doc'] . "/front/helpdesk.public.php$REDIRECT";
+         $url_redirect = PluginSinglesignonToolbox::getBaseURL() . "/front/helpdesk.public.php$REDIRECT";
       }
    } else {
       if ($_SESSION['glpiactiveprofile']['create_ticket_on_login'] && empty($REDIRECT)) {
-         $url_redirect = $CFG_GLPI['root_doc'] . "/front/ticket.form.php";
+         $url_redirect = PluginSinglesignonToolbox::getBaseURL() . "/front/ticket.form.php";
       } else {
-         $url_redirect = $CFG_GLPI['root_doc'] . "/front/central.php$REDIRECT";
+         $url_redirect = PluginSinglesignonToolbox::getBaseURL() . "/front/central.php$REDIRECT";
       }
    }
 
-   Html::nullHeader("Login", $CFG_GLPI["root_doc"] . '/index.php');
+   Html::nullHeader("Login", PluginSinglesignonToolbox::getBaseURL() . '/index.php');
    echo '<div class="center spaced"><a href="' . $url_redirect . '">' .
    __sso('Automatic redirection, else click') . '</a>';
    echo '<script type="text/javascript">
@@ -129,10 +129,10 @@ if ($user_id || $signon_provider->login()) {
 }
 
 // we have done at least a good login? No, we exit.
-Html::nullHeader("Login", $CFG_GLPI["root_doc"] . '/index.php');
+Html::nullHeader("Login", PluginSinglesignonToolbox::getBaseURL() . '/index.php');
 echo '<div class="center b">' . __('User not authorized to connect in GLPI') . '<br><br>';
 // Logout whit noAUto to manage auto_login with errors
-echo '<a href="' . $CFG_GLPI["root_doc"] . '/front/logout.php?noAUTO=1' .
+echo '<a href="' . PluginSinglesignonToolbox::getBaseURL() . '/front/logout.php?noAUTO=1' .
 str_replace("?", "&", $REDIRECT) . '" class="singlesignon">' . __('Log in again') . '</a></div>';
 echo '<script type="text/javascript">
    if (window.opener) {

--- a/inc/preference.class.php
+++ b/inc/preference.class.php
@@ -116,7 +116,7 @@ class PluginSinglesignonPreference extends CommonDBTM {
       }
       $canedit = Session::haveRight(User::$rightname, UPDATE);
       if ($canedit) {
-         echo "<form name='form' action=\"" . $CFG_GLPI['root_doc'] . "/plugins/singlesignon/front/user.form.php\" method='post'>";
+         echo "<form name='form' action=\"" . PluginSinglesignonToolbox::getBaseURL() . Plugin::getPhpDir("singlesignon", false) . "/front/user.form.php\" method='post'>";
       }
       echo Html::hidden('user_id', ['value' => $this->user_id]);
 

--- a/inc/provider.class.php
+++ b/inc/provider.class.php
@@ -274,7 +274,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
          echo "</tr>\n";
 
          $url = PluginSinglesignonToolbox::getCallbackUrl($ID);
-         $fullUrl = $this->getBaseURL() . $url;
+         $fullUrl = PluginSinglesignonToolbox::getBaseURL() . $url;
          echo "<tr class='tab_bg_1'>";
          echo "<td>" . __sso('Callback URL') . "</td>";
          echo "<td colspan='3'><a id='singlesignon_callbackurl' href='$fullUrl' data-url='$url'>$fullUrl</a></td>";
@@ -877,56 +877,6 @@ class PluginSinglesignonProvider extends CommonDBTM {
    }
 
    /**
-    * Get current URL without query string
-    * @return string
-    */
-   private function getBaseURL() {
-      $baseURL = "";
-      if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
-         $baseURL = ($_SERVER["HTTP_X_FORWARDED_PROTO"] == "https") ? "https://" : "http://";
-      } else if (isset($_SERVER["HTTPS"])) {
-         $baseURL = ($_SERVER["HTTPS"] == "on") ? "https://" : "http://";
-      } else {
-         $baseURL = "http://";
-      }
-      if (isset($_SERVER["HTTP_X_FORWARDED_HOST"])) {
-         $baseURL .= $_SERVER["HTTP_X_FORWARDED_HOST"];
-      } else if (isset($_SERVER["HTTP_X_FORWARDED_HOST"])) {
-         $baseURL .= $_SERVER["HTTP_X_FORWARDED_HOST"];
-      } else {
-         $baseURL .= $_SERVER["SERVER_NAME"];
-      }
-
-      $port = $_SERVER["SERVER_PORT"];
-      if (isset($_SERVER["HTTP_X_FORWARDED_PORT"])) {
-         $port = $_SERVER["HTTP_X_FORWARDED_PORT"];
-      }
-
-      if ($port != "80" && $port != "443") {
-         $baseURL .= ":" . $_SERVER["SERVER_PORT"];
-      }
-      return $baseURL;
-   }
-
-   /**
-    * Get current URL without query string
-    * @return string
-    */
-   private function getCurrentURL() {
-      $currentURL = $this->getBaseURL();
-
-      // $currentURL .= $_SERVER["REQUEST_URI"];
-      // Ignore Query String
-      if (isset($_SERVER["SCRIPT_NAME"])) {
-         $currentURL .= $_SERVER["SCRIPT_NAME"];
-      }
-      if (isset($_SERVER["PATH_INFO"])) {
-         $currentURL .= $_SERVER["PATH_INFO"];
-      }
-      return $currentURL;
-   }
-
-   /**
     *
     * @return boolean|string
     */
@@ -950,7 +900,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
             'state' => $state,
             'response_type' => 'code',
             'approval_prompt' => 'auto',
-            'redirect_uri' => $this->getCurrentURL(),
+            'redirect_uri' => PluginSinglesignonToolbox::getCurrentURL(),
          ];
 
          $params = Plugin::doHookFunction("sso:authorize_params", $params);
@@ -997,7 +947,7 @@ class PluginSinglesignonProvider extends CommonDBTM {
       $params = [
          'client_id' => $this->getClientId(),
          'client_secret' => $this->getClientSecret(),
-         'redirect_uri' => $this->getCurrentURL(),
+         'redirect_uri' => PluginSinglesignonToolbox::getCurrentURL(),
          'grant_type' => 'authorization_code',
          'code' => $this->_code,
       ];

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -37,7 +37,7 @@ class PluginSinglesignonToolbox {
    public static function getCallbackUrl($row, $query = []) {
       global $CFG_GLPI;
 
-      $url = $CFG_GLPI['root_doc'] . '/plugins/singlesignon/front/callback.php';
+      $url = Plugin::getPhpDir("singlesignon", false) . '/front/callback.php';
 
       $url .= "/provider/".$row;
 
@@ -108,7 +108,7 @@ class PluginSinglesignonToolbox {
          return null;
       }
 
-      return $CFG_GLPI['root_doc'] . '/plugins/singlesignon/front/picture.send.php?path=' . $path;
+      return PluginSinglesignonToolbox::getBaseURL() . Plugin::getPhpDir("singlesignon", false) . '/front/picture.send.php?path=' . $path;
    }
 
    static public function savePicture($src, $uniq_prefix = "") {
@@ -195,5 +195,55 @@ class PluginSinglesignonToolbox {
       $btn .= sprintf(__sso('Login with %s'), $data['name']);
       $btn .= '</a></span>';
       return $btn;
+   }
+
+   /**
+    * Get base URL without query string
+    * @return string
+    */
+   public static function getBaseURL() {
+      $baseURL = "";
+      if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+         $baseURL = ($_SERVER["HTTP_X_FORWARDED_PROTO"] == "https") ? "https://" : "http://";
+      } else if (isset($_SERVER["HTTPS"])) {
+         $baseURL = ($_SERVER["HTTPS"] == "on") ? "https://" : "http://";
+      } else {
+         $baseURL = "http://";
+      }
+      if (isset($_SERVER["HTTP_X_FORWARDED_HOST"])) {
+         $baseURL .= $_SERVER["HTTP_X_FORWARDED_HOST"];
+      } else if (isset($_SERVER["HTTP_X_FORWARDED_HOST"])) {
+         $baseURL .= $_SERVER["HTTP_X_FORWARDED_HOST"];
+      } else {
+         $baseURL .= $_SERVER["SERVER_NAME"];
+      }
+
+      $port = $_SERVER["SERVER_PORT"];
+      if (isset($_SERVER["HTTP_X_FORWARDED_PORT"])) {
+         $port = $_SERVER["HTTP_X_FORWARDED_PORT"];
+      }
+
+      if ($port != "80" && $port != "443") {
+         $baseURL .= ":" . $_SERVER["SERVER_PORT"];
+      }
+      return $baseURL;
+   }
+
+   /**
+    * Get current URL without query string
+    * @return string
+    */
+   public static function getCurrentURL() {
+      $currentURL = $this->getBaseURL();
+
+      // $currentURL .= $_SERVER["REQUEST_URI"];
+      // Ignore Query String
+      if (isset($_SERVER["SCRIPT_NAME"])) {
+         $currentURL .= $_SERVER["SCRIPT_NAME"];
+      }
+      if (isset($_SERVER["PATH_INFO"])) {
+         $currentURL .= $_SERVER["PATH_INFO"];
+      }
+      return $currentURL;
    }
 }

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -94,7 +94,7 @@ class PluginSinglesignonToolbox {
       return $data;
    }
 
-   static public function startsWith($haystack, $needle) {
+   public static function startsWith($haystack, $needle) {
       $length = strlen($needle);
       return (substr($haystack, 0, $length) === $needle);
    }
@@ -111,7 +111,7 @@ class PluginSinglesignonToolbox {
       return PluginSinglesignonToolbox::getBaseURL() . Plugin::getPhpDir("singlesignon", false) . '/front/picture.send.php?path=' . $path;
    }
 
-   static public function savePicture($src, $uniq_prefix = "") {
+   public static function savePicture($src, $uniq_prefix = "") {
 
       if (function_exists('Document::isImage') && !Document::isImage($src)) {
          return false;
@@ -234,7 +234,7 @@ class PluginSinglesignonToolbox {
     * @return string
     */
    public static function getCurrentURL() {
-      $currentURL = $this->getBaseURL();
+      $currentURL = PluginSinglesignonToolbox::getBaseURL();
 
       // $currentURL .= $_SERVER["REQUEST_URI"];
       // Ignore Query String

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -202,6 +202,12 @@ class PluginSinglesignonToolbox {
     * @return string
     */
    public static function getBaseURL() {
+      global $CFG_GLPI;
+
+      if (!empty($CFG_GLPI['url_base'])) {
+         return $CFG_GLPI['url_base'];
+      }
+
       $baseURL = "";
       if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
          $baseURL = ($_SERVER["HTTP_X_FORWARDED_PROTO"] == "https") ? "https://" : "http://";
@@ -210,6 +216,7 @@ class PluginSinglesignonToolbox {
       } else {
          $baseURL = "http://";
       }
+
       if (isset($_SERVER["HTTP_X_FORWARDED_HOST"])) {
          $baseURL .= $_SERVER["HTTP_X_FORWARDED_HOST"];
       } else if (isset($_SERVER["HTTP_X_FORWARDED_HOST"])) {


### PR DESCRIPTION
PT-BR:

Boa noite, Edgar!
Movi as funções PHP ``getBaseURL()`` e ``getCurrentURL()`` para a Toolbox para que outras partes do plug-in possam reaproveitar essas funções no futuro. Também fiz alguns aprimoramentos que podem ajudar usuários que usam o GLPI atrás de um proxy reverso como HAProxy ou NGINX (muito comum para empresas que usam certificados públicos Let's Encrypt) para todas as funções do plug-in, além de priorizar a "URL de Aplicativo" (se configurada) em Configurar > Geral. Também usei a função ``getPhpDir()`` para detectar o caminho relativo do diretório de instalação do plug-in, visto que o plug-in pode vir a ser disponibilizado no Marketplace do GLPI no futuro que instala o plug-in em um diretório diferente. 

EN-US:

This PR may fix problems when using this plug-in behind reverse proxies like HA-Proxy since now it reads the HTTP headers through ``getBaseURL()`` instead of relying solely on GLPI URL parameters (see https://github.com/edgardmessias/glpi-singlesignon/issues/98)

It also detects the plug-in folder through ``getPhpDir()`` function as this plug-in maybe installed through GLPI Marketplace into the future.
