### PR TITLE
fix: multiple critical errors / Introducing new features

### DIFF
--- a/front/callback.php
+++ b/front/callback.php
@@ -111,7 +111,11 @@ if ($user_id || $signon_provider->login()) {
 
    $url_redirect = '';
 
-   if ($_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
+   // Check if session profile is set
+   if (!isset($_SESSION["glpiactiveprofile"]) || !isset($_SESSION["glpiactiveprofile"]["interface"])) {
+      // Default to central page
+      $url_redirect = PluginSinglesignonToolbox::getBaseURL() . "/front/central.php$REDIRECT";
+   } else if ($_SESSION["glpiactiveprofile"]["interface"] == "helpdesk") {
       if ($_SESSION['glpiactiveprofile']['create_ticket_on_login'] && empty($REDIRECT)) {
          $url_redirect = PluginSinglesignonToolbox::getBaseURL() . "/front/helpdesk.public.php?create_ticket=1";
       } else {

--- a/hook.php
+++ b/hook.php
@@ -59,7 +59,7 @@ function plugin_singlesignon_install() {
    if (!$DB->tableExists($providersTable)) {
       $DB->doQuery(
          "CREATE TABLE `$providersTable` (
-            `id`                         INT NOT NULL AUTO_INCREMENT,
+            `id`                         INT UNSIGNED NOT NULL AUTO_INCREMENT,
             `is_default`                 TINYINT(1) NOT NULL DEFAULT '0',
             `popup`                      TINYINT(1) NOT NULL DEFAULT '0',
             `split_domain`               TINYINT(1) NOT NULL DEFAULT '0',
@@ -132,18 +132,88 @@ function plugin_singlesignon_install() {
       );
    }
 
-   if (version_compare($currentVersion, '1.3.0', '<') && !$DB->tableExists($providersUsersTable)) {
+   // Version 1.6.0 migrations
+   if (version_compare($currentVersion, '1.6.0', '<')) {
+      // Add SSL verification options
+      $migration->addField($providersTable, 'ssl_verifyhost', 'bool', [
+         'value' => 1,  // Default to enabled for security
+      ]);
+      $migration->addField($providersTable, 'ssl_verifypeer', 'bool', [
+         'value' => 1,  // Default to enabled for security
+      ]);
+
+      // Add group-based access control fields
+      $migration->addField(
+         $providersTable,
+         'allowed_groups',
+         'text',
+         [
+            'nodefault' => true,
+            'null'      => true,
+         ]
+      );
+
+      // Add custom groups claim field
+      $migration->addField(
+         $providersTable,
+         'groups_claim',
+         'string',
+         [
+            'nodefault' => true,
+            'null'      => true,
+         ]
+      );
+
+      // Fix signed INT to UNSIGNED for GLPI 11 compliance
+      $columns = $DB->listFields($providersTable);
+      if (isset($columns['id']) && isset($columns['id']['Type'])) {
+         if (stripos($columns['id']['Type'], 'unsigned') === false) {
+            $DB->doQuery("ALTER TABLE `$providersTable` MODIFY `id` INT UNSIGNED NOT NULL AUTO_INCREMENT");
+         }
+      }
+   }
+
+   // Create the providers_users linking table if it doesn't exist
+   // This table is needed to link OAuth remote_id to GLPI users
+   if (version_compare($currentVersion, '1.6.0', '<') && !$DB->tableExists($providersUsersTable)) {
       $DB->doQuery(
          "CREATE TABLE `$providersUsersTable` (
-            `id` INT NOT NULL AUTO_INCREMENT,
-            `plugin_singlesignon_providers_id` INT NOT NULL DEFAULT '0',
-            `users_id` INT NOT NULL DEFAULT '0',
+            `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `plugin_singlesignon_providers_id` INT UNSIGNED NOT NULL DEFAULT '0',
+            `users_id` INT UNSIGNED NOT NULL DEFAULT '0',
             `remote_id` VARCHAR(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
             PRIMARY KEY (`id`),
             UNIQUE KEY `unicity` (`plugin_singlesignon_providers_id`,`users_id`),
             UNIQUE KEY `unicity_remote` (`plugin_singlesignon_providers_id`,`remote_id`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
       );
+   } else {
+      // Table exists - check if columns need to be updated to UNSIGNED
+      // This auto-fixes the GLPI 11 deprecation warning about signed integers
+      $columns = $DB->listFields($providersUsersTable);
+
+      $needsUpdate = false;
+      $columnsToUpdate = ['id', 'plugin_singlesignon_providers_id', 'users_id'];
+
+      foreach ($columnsToUpdate as $column) {
+         if (isset($columns[$column]) && isset($columns[$column]['Type'])) {
+            // Check if the column type contains 'unsigned' (case insensitive)
+            if (stripos($columns[$column]['Type'], 'unsigned') === false) {
+               $needsUpdate = true;
+               break;
+            }
+         }
+      }
+
+      if ($needsUpdate) {
+         // Update columns to UNSIGNED to fix GLPI 11 deprecation warnings
+         $DB->doQuery(
+            "ALTER TABLE `$providersUsersTable`
+               MODIFY `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+               MODIFY `plugin_singlesignon_providers_id` INT UNSIGNED NOT NULL DEFAULT '0',
+               MODIFY `users_id` INT UNSIGNED NOT NULL DEFAULT '0'"
+         );
+      }
    }
 
    if (!countElementsInTable('glpi_displaypreferences', ['itemtype' => 'PluginSinglesignonProvider'])) {
@@ -173,6 +243,9 @@ function plugin_singlesignon_uninstall() {
 
    $config = new Config();
    $config->deleteConfigurationValues('plugin:singlesignon');
+
+   // Explicitly remove plugin config from database to ensure clean uninstall
+   $DB->delete('glpi_configs', ['context' => 'plugin:singlesignon']);
 
    $providersUsersTable = 'glpi_plugin_singlesignon_providers_users';
    $providersTable = 'glpi_plugin_singlesignon_providers';

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@ use Glpi\Plugin\Hooks;
 use GlpiPlugin\Singlesignon\LoginRenderer;
 use GlpiPlugin\Singlesignon\Preference;
 use GlpiPlugin\Singlesignon\Provider;
-define('PLUGIN_SINGLESIGNON_VERSION', '1.5.1');
+define('PLUGIN_SINGLESIGNON_VERSION', '1.6.0');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_SINGLESIGNON_MIN_GLPI', '11.0.0');
@@ -76,6 +76,9 @@ function plugin_init_singlesignon() {
    $PLUGIN_HOOKS['menu_toadd']['singlesignon'] = [
       'config'  => Provider::class,
    ];
+
+   // Make the picture.send.php page public again.
+   Firewall::addPluginStrategyForLegacyScripts('singlesignon', '#^/front/picture.send.php$#', Firewall::STRATEGY_NO_CHECK);
 }
 
 // Get the name and the version of the plugin - Needed

--- a/src/LoginRenderer.php
+++ b/src/LoginRenderer.php
@@ -32,7 +32,7 @@ class LoginRenderer
                 'label'   => sprintf(\__sso('Login with %s'), $row['name']),
                 'popup'   => (bool)$row['popup'],
                 'style'   => self::buildButtonStyle($row),
-                'picture' => $row['picture'] ? Toolbox::getPictureUrl($row['picture']) : null,
+                'picture' => isset($row['picture']) && $row['picture'] ? Toolbox::getPictureUrl($row['picture']) : null,
             ];
         }
 

--- a/src/Preference.php
+++ b/src/Preference.php
@@ -46,7 +46,7 @@ class Preference extends \CommonDBTM {
    }
 
    public function loadProviders() {
-      $signon_provider = new PluginSinglesignonProvider();
+      $signon_provider = new Provider();
 
       $condition = '`is_active` = 1';
       if (version_compare(GLPI_VERSION, '9.4', '>=')) {
@@ -54,7 +54,7 @@ class Preference extends \CommonDBTM {
       }
       $this->providers = $signon_provider->find($condition);
 
-      $provider_user = new PluginSinglesignonProvider_User();
+      $provider_user = new \PluginSinglesignonProvider_User();
 
       $condition = "`users_id` = {$this->user_id}";
       if (version_compare(GLPI_VERSION, '9.4', '>=')) {
@@ -73,7 +73,7 @@ class Preference extends \CommonDBTM {
          return false;
       }
 
-      $provider_user = new PluginSinglesignonProvider_User();
+      $provider_user = new \PluginSinglesignonProvider_User();
       $condition = "`users_id` = {$this->user_id} AND `id` IN (" . implode(',', $ids) . ")";
       if (version_compare(GLPI_VERSION, '9.4', '>=')) {
          $condition = [$condition];
@@ -143,7 +143,7 @@ class Preference extends \CommonDBTM {
    }
 
    function showFormPreference(\CommonGLPI $item) {
-      $user = new User();
+      $user = new \User();
       if (!$user->can($this->user_id, READ) && ($this->user_id != \Session::getLoginUserID())) {
          return false;
       }
@@ -201,8 +201,8 @@ class Preference extends \CommonDBTM {
          echo "<tr><th colspan='2'>" . \__sso('Linked accounts') . "</th></tr>";
 
          foreach ($this->providers_users as $pu) {
-            /** @var PluginSinglesignonProvider */
-            $provider = PluginSinglesignonProvider::getById($pu['plugin_singlesignon_providers_id']);
+            /** @var Provider */
+            $provider = Provider::getById($pu['plugin_singlesignon_providers_id']);
 
             echo "<tr><td>";
             echo $provider->fields['name'] . ' (ID:' . $pu['remote_id'] . ')';

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -226,12 +226,49 @@ class Provider extends \CommonDBTM {
       echo "</td></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
+      echo "<td>" . \__sso('Allowed Groups');
+      echo "&nbsp;";
+      \Html::showToolTip(nl2br(\__sso('Restrict login to users in specific OAuth groups. Enter group names or IDs separated by commas (e.g., admin,developers,staff). Leave empty to allow all users. The user must belong to at least one of the specified groups.')));
+      echo "</td>";
+      echo "<td colspan='3'><input type='text' style='width:96%' name='allowed_groups' value='" . ($this->fields["allowed_groups"] ?? '') . "' class='form-control' placeholder='admin,developers,staff'></td>";
+      echo "</tr>\n";
+
+      echo "<tr class='tab_bg_1'>";
       echo "<td>" . \__sso("Use Email as Login") . "<td>";
       \Dropdown::showYesNo("use_email_for_login", $this->fields["use_email_for_login"]);
       echo "</td>";
       echo "<td>" . \__sso('Split Name') . "<td>";
       \Dropdown::showYesNo("split_name", $this->fields["split_name"]);
       echo "</td>";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<th colspan='4'>" . \__sso('Advanced Settings') . "</th>";
+      echo "</tr>\n";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>" . \__sso('SSL Verify Host');
+      echo "&nbsp;";
+      \Html::showToolTip(nl2br(\__sso('Verify the SSL certificate hostname. Disable only for testing with self-signed certificates.')));
+      echo "</td>";
+      echo "<td>";
+      \Dropdown::showYesNo("ssl_verifyhost", $this->fields["ssl_verifyhost"] ?? 1);
+      echo "</td>";
+      echo "<td>" . \__sso('SSL Verify Peer');
+      echo "&nbsp;";
+      \Html::showToolTip(nl2br(\__sso('Verify the SSL certificate authenticity. Disable only for testing with self-signed certificates.')));
+      echo "</td>";
+      echo "<td>";
+      \Dropdown::showYesNo("ssl_verifypeer", $this->fields["ssl_verifypeer"] ?? 1);
+      echo "</td>";
+      echo "</tr>\n";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>" . \__sso('Groups Claim Name');
+      echo "&nbsp;";
+      \Html::showToolTip(nl2br(\__sso('Override the claim name used to extract user groups from the OAuth response. Supports dot notation for nested fields (e.g., "realm_access.roles", "custom.groups"). Leave empty to use default claim names (groups, roles, realm_access.roles).')));
+      echo "</td>";
+      echo "<td colspan='3'><input type='text' style='width:96%' name='groups_claim' value='" . ($this->fields["groups_claim"] ?? '') . "' class='form-control' placeholder='groups'></td>";
+      echo "</tr>\n";
 
       echo "<tr class='tab_bg_1'>";
       echo "<th colspan='4'>" . __('Personalization') . "</th>";
@@ -344,6 +381,14 @@ class Provider extends \CommonDBTM {
       }
 
       return true;
+   }
+
+   public function getEmpty() {
+      parent::getEmpty();
+
+      // Set secure defaults for new providers
+      $this->fields['ssl_verifyhost'] = 1;
+      $this->fields['ssl_verifypeer'] = 1;
    }
 
    function prepareInputForAdd($input) {
@@ -864,6 +909,16 @@ class Provider extends \CommonDBTM {
          $fields['scope'] = $value;
       }
 
+      // For generic OAuth providers, ensure 'openid' scope is included
+      // This is required for the userinfo endpoint to work properly
+      if ($type === 'generic' && !empty($fields['scope'])) {
+         $scopes = explode(' ', $fields['scope']);
+         if (!in_array('openid', $scopes)) {
+            array_unshift($scopes, 'openid');
+            $fields['scope'] = implode(' ', $scopes);
+         }
+      }
+
       $fields = \Plugin::doHookFunction("sso:scope", $fields);
 
       return $fields['scope'];
@@ -1040,8 +1095,8 @@ class Provider extends \CommonDBTM {
          ],
          CURLOPT_POST => true,
          CURLOPT_POSTFIELDS => http_build_query($params),
-         CURLOPT_SSL_VERIFYHOST => false,
-         CURLOPT_SSL_VERIFYPEER => false,
+         CURLOPT_SSL_VERIFYHOST => ($this->fields['ssl_verifyhost'] ?? true) ? 2 : 0,
+         CURLOPT_SSL_VERIFYPEER => ($this->fields['ssl_verifypeer'] ?? true) ? 2 : 0,
       ]);
 
       if ($this->debug) {
@@ -1098,25 +1153,68 @@ class Provider extends \CommonDBTM {
 
       $headers = \Plugin::doHookFunction("sso:resource_owner_header", $headers);
 
-      $content = \Toolbox::callCurl($url, [
-         CURLOPT_HTTPHEADER => $headers,
-         CURLOPT_SSL_VERIFYHOST => false,
-         CURLOPT_SSL_VERIFYPEER => false,
-      ]);
+      if ($this->debug) {
+         print_r("Headers:\n");
+         print_r($headers);
+         print_r("\n");
+      }
+
+      $ch = curl_init($url);
+      curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+      curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, ($this->fields['ssl_verifyhost'] ?? true) ? 2 : 0);
+      curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, ($this->fields['ssl_verifypeer'] ?? true) ? 2 : 0);
+      curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+      $content = curl_exec($ch);
+      $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+      $curl_error = curl_error($ch);
+      // curl_close() is deprecated in PHP 8.0+ - handles are auto-closed
 
       if ($this->debug) {
          print_r("\ngetResourceOwner:\n");
+         print_r("\nHTTP Status Code: " . $http_code . "\n");
+         if ($http_code === 403) {
+            print_r(">>> 403 Forbidden: The userinfo endpoint rejected the access token.\n");
+            print_r(">>> Common causes:\n");
+            print_r(">>>   1. Missing 'openid' scope - ensure scope includes: openid profile email\n");
+            print_r(">>>   2. Client not authorized to access userinfo endpoint in your IdP\n");
+            print_r(">>>   3. Token audience mismatch\n");
+            print_r(">>> Current configured scope: " . ($this->fields['scope'] ?? '(not set)') . "\n");
+         } else if ($http_code === 401) {
+            print_r(">>> 401 Unauthorized: Access token is invalid or expired.\n");
+         } else if ($http_code >= 400) {
+            print_r(">>> Error response from userinfo endpoint.\n");
+         }
+         if ($curl_error) {
+            print_r("CURL Error: " . $curl_error . "\n");
+         }
+         print_r("Raw content from userinfo endpoint:\n");
+         print_r($content);
+         print_r("\n");
+         print_r("Content length: " . strlen($content) . "\n");
       }
 
       try {
          $data = json_decode($content, true);
          if ($this->debug) {
+            print_r("\nDecoded data:\n");
             print_r($data);
          }
+
+         // Check if json_decode failed
+         if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+            if ($this->debug) {
+               print_r("\nJSON decode error: " . json_last_error_msg() . "\n");
+            }
+            return false;
+         }
+
          $this->_resource_owner = $data;
       } catch (\Exception $ex) {
          if ($this->debug) {
-            print_r($content);
+            print_r("\nException occurred:\n");
+            print_r($ex->getMessage());
+            print_r("\n");
          }
          return false;
       }
@@ -1128,8 +1226,8 @@ class Provider extends \CommonDBTM {
          $email_url = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))";
          $content = \Toolbox::callCurl($email_url, [
             CURLOPT_HTTPHEADER => $headers,
-            CURLOPT_SSL_VERIFYHOST => false,
-            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_SSL_VERIFYHOST => ($this->fields['ssl_verifyhost'] ?? true) ? 2 : 0,
+            CURLOPT_SSL_VERIFYPEER => ($this->fields['ssl_verifypeer'] ?? true) ? 2 : 0,
          ]);
 
          try {
@@ -1147,11 +1245,137 @@ class Provider extends \CommonDBTM {
       return $this->_resource_owner;
    }
 
+   /**
+    * Extract user groups from OAuth resource response
+    * Supports custom claim names with dot notation
+    *
+    * @param array $resource_array The OAuth resource owner data
+    * @return array Array of group names
+    */
+   protected function extractUserGroups($resource_array) {
+      $groups = [];
+
+      // Check if a custom groups claim is configured
+      if (!empty($this->fields['groups_claim'])) {
+         $claim_path = $this->fields['groups_claim'];
+
+         if ($this->debug) {
+            print_r("\nUsing custom groups claim: $claim_path\n");
+         }
+
+         // Support dot notation for nested fields (e.g., "realm_access.roles")
+         $keys = explode('.', $claim_path);
+         $value = $resource_array;
+
+         foreach ($keys as $key) {
+            if (isset($value[$key])) {
+               $value = $value[$key];
+            } else {
+               $value = null;
+               break;
+            }
+         }
+
+         if ($value !== null) {
+            if (is_array($value)) {
+               $groups = array_merge($groups, $value);
+            } elseif (is_string($value)) {
+               // Support comma or space-separated strings
+               $groups = array_merge($groups, preg_split('/[,\s]+/', $value));
+            }
+         }
+
+         if ($this->debug) {
+            print_r("Groups from custom claim: ");
+            var_dump($groups);
+         }
+
+         // If custom claim is configured, only use that claim
+         if (!empty($groups)) {
+            return array_values(array_filter(array_unique($groups), function($group) {
+               return !empty($group);
+            }));
+         }
+      }
+
+      // Fall back to checking standard group field names
+      $group_fields = ['groups', 'roles', 'group', 'role'];
+
+      foreach ($group_fields as $field) {
+         if (isset($resource_array[$field])) {
+            if (is_array($resource_array[$field])) {
+               $groups = array_merge($groups, $resource_array[$field]);
+            } elseif (is_string($resource_array[$field])) {
+               $groups = array_merge($groups, preg_split('/[,\s]+/', $resource_array[$field]));
+            }
+         }
+      }
+
+      // Keycloak-specific: realm_access.roles
+      if (isset($resource_array['realm_access']['roles']) && is_array($resource_array['realm_access']['roles'])) {
+         $groups = array_merge($groups, $resource_array['realm_access']['roles']);
+      }
+
+      // Keycloak-specific: resource_access.{client_id}.roles
+      if (isset($resource_array['resource_access']) && is_array($resource_array['resource_access'])) {
+         foreach ($resource_array['resource_access'] as $client_roles) {
+            if (isset($client_roles['roles']) && is_array($client_roles['roles'])) {
+               $groups = array_merge($groups, $client_roles['roles']);
+            }
+         }
+      }
+
+      // Remove duplicates, empty values, and reindex array
+      return array_values(array_filter(array_unique($groups), function($group) {
+         return !empty($group);
+      }));
+   }
+
    public function findUser() {
       $resource_array = $this->getResourceOwner();
 
       if (!$resource_array) {
          return false;
+      }
+
+      // Check group-based access control
+      if (!empty($this->fields['allowed_groups'])) {
+         $allowed_groups = array_filter(array_map('trim', explode(',', $this->fields['allowed_groups'])));
+
+         // Skip group check if no valid groups after filtering empty strings
+         if (empty($allowed_groups)) {
+            if ($this->debug) {
+               print_r("\nGroup-based access control: allowed_groups field contains only empty values, skipping check\n");
+            }
+         } else {
+            $user_groups = $this->extractUserGroups($resource_array);
+
+            if ($this->debug) {
+               print_r("\nGroup-based access control enabled\n");
+               print_r("Allowed groups: ");
+               var_dump($allowed_groups);
+               print_r("User groups: ");
+               var_dump($user_groups);
+            }
+
+            $has_access = false;
+            foreach ($user_groups as $user_group) {
+               if (in_array($user_group, $allowed_groups)) {
+                  $has_access = true;
+                  if ($this->debug) {
+                     print_r("Access granted - user is in group: $user_group\n");
+                  }
+                  break;
+               }
+            }
+
+            if (!$has_access) {
+               if ($this->debug) {
+                  print_r("Access denied - user is not in any allowed group\n");
+               }
+               return false;
+            }
+         }
       }
 
       $user = new \User();
@@ -1173,20 +1397,35 @@ class Provider extends \CommonDBTM {
       }
 
       if ($remote_id) {
-         $link = new \PluginSinglesignonProvider_User();
-         $condition = "`remote_id` = '{$remote_id}' AND `plugin_singlesignon_providers_id` = {$this->fields['id']}";
-         if (version_compare(GLPI_VERSION, '9.4', '>=')) {
-            $condition = [$condition];
-         }
-         $links = $link->find($condition);
-         if (!empty($links) && $first = reset($links)) {
-            $id = $first['users_id'];
-         }
+         try {
+            $link = new \PluginSinglesignonProvider_User();
+            $condition = "`remote_id` = '{$remote_id}' AND `plugin_singlesignon_providers_id` = {$this->fields['id']}";
 
-         $remote_id;
+            if (version_compare(GLPI_VERSION, '9.4', '>=')) {
+               $condition = [$condition];
+            }
+
+            $links = $link->find($condition);
+
+            if (!empty($links) && $first = reset($links)) {
+               $id = $first['users_id'];
+               if ($this->debug) {
+                  print_r("Found user by remote_id link: $id\n");
+               }
+            }
+         } catch (\Exception $ex) {
+            if ($this->debug) {
+               print_r("\nException during remote_id lookup:\n");
+               print_r($ex->getMessage());
+               print_r("\n");
+            }
+         }
       }
 
       if (is_numeric($id) && $user->getFromDB($id)) {
+         if ($this->debug) {
+            print_r("User found by ID, returning\n");
+         }
          return $user;
       }
 
@@ -1239,6 +1478,9 @@ class Provider extends \CommonDBTM {
                }
 
                if (!$isAuthorized) {
+                  if ($this->debug) {
+                     print_r("\nLogin not authorized by domain restriction\n");
+                  }
                   return false;
                }
                if ($split) {
@@ -1251,6 +1493,9 @@ class Provider extends \CommonDBTM {
       }
 
       if ($login && $user->getFromDBbyName($login)) {
+         if ($this->debug) {
+            print_r("User found by login name, returning\n");
+         }
          return $user;
       }
 
@@ -1262,16 +1507,19 @@ class Provider extends \CommonDBTM {
 
       $bOk = true;
       if ($email && $user->getFromDBbyEmail($email, $default_condition)) {
+         if ($this->debug) {
+            print_r("User found by email, returning\n");
+         }
          return $user;
       } else {
          $bOk = false;
       }
 
-      // var_dump($bOk);
-      // die();
-
       // If the user does not exist in the database and the provider is google
       if (static::getClientType() == "google" && !$bOk) {
+         if ($this->debug) {
+            print_r("\nAttempting to create user for Google provider\n");
+         }
          // Generates an api token and a personal token... probably not necessary
          $tokenAPI = base_convert(hash('sha256', time() . mt_rand()), 16, 36);
          $tokenPersonnel = base_convert(hash('sha256', time() . mt_rand()), 16, 36);
@@ -1309,20 +1557,49 @@ class Provider extends \CommonDBTM {
 
       // If the user does not exist in the database and the provider is generic (Ex: azure ad without common tenant)
       if (static::getClientType() == "generic" && !$bOk) {
+         if ($this->debug) {
+            print_r("\nAttempting to create user for Generic provider\n");
+         }
          try {
             // Generates an api token and a personal token... probably not necessary
             $tokenAPI = base_convert(hash('sha256', time() . mt_rand()), 16, 36);
             $tokenPersonnel = base_convert(hash('sha256', time() . mt_rand()), 16, 36);
 
             $splitname = $this->fields['split_name'];
-            $firstLastArray = ($splitname) ? preg_split('/ /', $resource_array['name'], 2) : preg_split('/ /', $resource_array['displayName'], 2);
+            $firstname = '';
+            $realname = '';
+
+            // Try to get name from various fields
+            if ($splitname && isset($resource_array['name']) && !empty($resource_array['name'])) {
+               $firstLastArray = preg_split('/ /', $resource_array['name'], 2);
+               $firstname = $firstLastArray[0];
+               $realname = isset($firstLastArray[1]) ? $firstLastArray[1] : '';
+            } else if (isset($resource_array['displayName']) && !empty($resource_array['displayName'])) {
+               $firstLastArray = preg_split('/ /', $resource_array['displayName'], 2);
+               $firstname = $firstLastArray[0];
+               $realname = isset($firstLastArray[1]) ? $firstLastArray[1] : '';
+            } else if (isset($resource_array['given_name']) && isset($resource_array['family_name'])) {
+               // OpenID Connect standard claims
+               $firstname = $resource_array['given_name'];
+               $realname = $resource_array['family_name'];
+            } else if (isset($resource_array['preferred_username'])) {
+               // Fallback: use preferred_username as firstname
+               $firstname = $resource_array['preferred_username'];
+               $realname = '';
+            } else if ($login) {
+               // The user will have empty realname if no other info is available
+            }
+
+            if ($this->debug) {
+               print_r("\nUser creation - firstname: $firstname, realname: $realname\n");
+            }
 
             $userPost = [
                'name' => $login,
                'add' => 1,
                'password' => '',
-               'realname' => $firstLastArray[1],
-               'firstname' => $firstLastArray[0],
+               'realname' => $realname,
+               'firstname' => $firstname,
                'api_token' => $tokenAPI,
                'api_token_date' => date("Y-m-d H:i:s"),
                'personal_token' => $tokenPersonnel,
@@ -1347,7 +1624,12 @@ class Provider extends \CommonDBTM {
             //$user->check(-1, CREATE, $userPost);
             $newID = $user->add($userPost);
 
-            // var_dump($newID);
+            if (!$newID) {
+               if ($this->debug) {
+                  print_r("\nUser creation failed!\n");
+               }
+               return false;
+            }
 
             $profils = 0;
             // Verification default profiles exist in the entity
@@ -1355,6 +1637,9 @@ class Provider extends \CommonDBTM {
             // In this case, we retrieve a profile and an entity and assign these values ​​to it.
             // The administrator can change these values ​​later.
             if (0 == \Profile::getDefault()) {
+               if ($this->debug) {
+                  print_r("\nNo default profile found, assigning first available profile\n");
+               }
                // No default profiles
                // Profile recovery and assignment
                global $DB;
@@ -1367,9 +1652,19 @@ class Provider extends \CommonDBTM {
                foreach ($DB->request('glpi_entities') as $data) {
                   array_push($datasEntities, $data);
                }
+
+               if ($this->debug) {
+                  print_r("Available profiles: " . count($datasProfiles) . "\n");
+                  print_r("Available entities: " . count($datasEntities) . "\n");
+               }
+
                if (count($datasProfiles) > 0 && count($datasEntities) > 0) {
                   $profils = $datasProfiles[0]['id'];
                   $entitie = $datasEntities[0]['id'];
+
+                  if ($this->debug) {
+                     print_r("Assigning profile ID: $profils, entity ID: $entitie\n");
+                  }
 
                   $profile   = new \Profile_User();
                   $userProfile['users_id'] = intval($user->fields['id']);
@@ -1377,16 +1672,46 @@ class Provider extends \CommonDBTM {
                   $userProfile['is_recursive'] = 0;
                   $userProfile['profiles_id'] = intval($profils);
                   $userProfile['add'] = "Ajouter";
-                  $profile->add($userProfile);
+                  $profileResult = $profile->add($userProfile);
+
+                  if ($this->debug) {
+                     print_r("Profile assignment result: ");
+                     var_dump($profileResult);
+                  }
+
+                  if (!$profileResult) {
+                     if ($this->debug) {
+                        print_r("Profile assignment failed!\n");
+                     }
+                     return false;
+                  }
                } else {
+                  if ($this->debug) {
+                     print_r("No profiles or entities available!\n");
+                  }
                   return false;
+               }
+            } else {
+               if ($this->debug) {
+                  print_r("\nDefault profile exists, will be assigned automatically\n");
                }
             }
 
             return $user;
          } catch (\Exception $ex) {
+            if ($this->debug) {
+               print_r("\nException during user creation:\n");
+               print_r($ex->getMessage());
+               print_r("\n");
+               print_r($ex->getTraceAsString());
+               print_r("\n");
+            }
             return false;
          }
+      }
+
+      if ($this->debug) {
+         print_r("\nReached end of findUser() - no user found or created\n");
       }
 
       return false;
@@ -1507,8 +1832,8 @@ class Provider extends \CommonDBTM {
          $photo_url = "https://graph.microsoft.com/v1.0/me/photo/\$value";
          $img = \Toolbox::callCurl($photo_url, [
             CURLOPT_HTTPHEADER => $headers,
-            CURLOPT_SSL_VERIFYHOST => false,
-            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_SSL_VERIFYHOST => ($this->fields['ssl_verifyhost'] ?? true) ? 2 : 0,
+            CURLOPT_SSL_VERIFYPEER => ($this->fields['ssl_verifypeer'] ?? true) ? 2 : 0,
          ]);
          if (!empty($img)) {
             /* if ($this->debug) {


### PR DESCRIPTION
### Important: All my tests are against the Keycloak provider.

This PR adresses the following errors:

## 1. Critical error from GLPI when trying to connect through a provider
<img width="1921" height="964" alt="image" src="https://github.com/user-attachments/assets/dfc3ffee-139f-49e2-a581-967df0be1c31" />

Error trace:
```
[2025-11-19 14:07:26] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "MySQL query error: Table 'glpidb.glpi_plugin_singlesignon_providers_users' doesn't exist (1146) in SQL query "SELECT * FROM `glpi_plugin_singlesignon_providers_users` WHERE (`remote_id` = '2911fee0-b56a-4649-9967-64626de5987d' AND `plugin_singlesignon_providers_id` = 1)"." at DBmysql.php line 371
  Backtrace :
  ./src/DBmysql.php:371                              
  ./src/DBmysqlIterator.php:123                      DBmysql->doQuery()
  ./src/DBmysql.php:1040                             DBmysqlIterator->execute()
  ./src/CommonDBTM.php:630                           DBmysql->request()
  ./plugins/singlesignon/src/Provider.php:1181       CommonDBTM->find()
  ./plugins/singlesignon/src/Provider.php:1396       GlpiPlugin\Singlesignon\Provider->findUser()
  ./plugins/singlesignon/front/callback.php:103      GlpiPlugin\Singlesignon\Provider->login()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```

#### Source of the error:
`version_compare($currentVersion, '1.3.0', '<') `; The plugin version is currently 1.5.x, and therefore it doesn't pass the first check and never creates the table for fresh installations... I don't know why this check is here, but it has to be either removed (as I did) or improved.

## 2. Error when accessing user's SSO tab

<img width="1921" height="964" alt="image" src="https://github.com/user-attachments/assets/314eb206-048f-4acc-bb61-17dbf8aad3fa" />

Error trace: 
```
[2025-11-20 10:41:29] glpi.CRITICAL:   *** Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\ClassNotFoundError: "Attempted to load class "User" from namespace "GlpiPlugin\Singlesignon".
Did you forget a "use" statement for e.g. "Sabre\CalDAV\Principal\User" or "Glpi\OAuth\User"?" at Preference.php line 146
  Backtrace :
  ./plugins/singlesignon/src/Preference.php:146      
  ./plugins/singlesignon/src/Preference.php:109      GlpiPlugin\Singlesignon\Preference->showFormPreference()
  ./src/CommonGLPI.php:694                           GlpiPlugin\Singlesignon\Preference::displayTabContentForItem()
  ./ajax/common.tabs.php:108                         CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```

#### Source of the error:

Basically missing some `\` before calling a class.

## 3. Warning about the use of signed integers in the database

If the database exists, fields will be migrated into unsigned int

Error trace:
```
[2025-11-20 10:54:06] glpi.WARNING:   *** User Warning: Usage of signed integers in primary or foreign keys is discouraged, please use unsigned integers instead in `glpi_plugin_singlesignon_providers_users`.`id`. at DBmysql.php line 2137
  Backtrace :
  ./src/DBmysql.php:2137                             
  ./src/DBmysql.php:367                              DBmysql->checkForDeprecatedTableOptions()
  ./plugins/singlesignon/hook.php:138                DBmysql->doQuery()
  ./src/Plugin.php:1200                              plugin_singlesignon_install()
  ./src/Glpi/Console/Plugin/InstallCommand.php:128   Plugin->install()
  ./vendor/symfony/console/Command/Command.php:326   Glpi\Console\Plugin\InstallCommand->execute()
  ./vendor/symfony/console/Application.php:1088      Symfony\Component\Console\Command\Command->run()
  ./src/Glpi/Console/Application.php:330             Symfony\Component\Console\Application->doRunCommand()
  ./vendor/symfony/console/Application.php:324       Glpi\Console\Application->doRunCommand()
  ./vendor/symfony/console/Application.php:175       Symfony\Component\Console\Application->doRun()
  ./bin/console:144                                  Symfony\Component\Console\Application->run()
[2025-11-20 16:58:58] glpi.WARNING:   *** User Warning: Usage of signed integers in primary or foreign keys is discouraged, please use unsigned integers instead in `glpi_plugin_singlesignon_providers`.`id`. at DBmysql.php line 2137
  Backtrace :
  ./src/DBmysql.php:2137                             
  ./src/DBmysql.php:367                              DBmysql->checkForDeprecatedTableOptions()
  ./plugins/singlesignon/hook.php:62                 DBmysql->doQuery()
  ./src/Plugin.php:1200                              plugin_singlesignon_install()
  ./src/Glpi/Console/Plugin/InstallCommand.php:128   Plugin->install()
  ./vendor/symfony/console/Command/Command.php:326   Glpi\Console\Plugin\InstallCommand->execute()
  ./vendor/symfony/console/Application.php:1088      Symfony\Component\Console\Command\Command->run()
  ./src/Glpi/Console/Application.php:330             Symfony\Component\Console\Application->doRunCommand()
  ./vendor/symfony/console/Application.php:324       Glpi\Console\Application->doRunCommand()
  ./vendor/symfony/console/Application.php:175       Symfony\Component\Console\Application->doRun()
  ./bin/console:144                                  Symfony\Component\Console\Application->run()
```

#### Result

```
+-------------+-------------+-------------+------------+----------------+
| COLUMN_NAME | COLUMN_TYPE | IS_NULLABLE | COLUMN_KEY | EXTRA          |
+-------------+-------------+-------------+------------+----------------+
| id          | int(11)     | NO          | PRI        | auto_increment |
+-------------+-------------+-------------+------------+----------------+
```

```
+-------------+------------------+-------------+------------+----------------+
| COLUMN_NAME | COLUMN_TYPE      | IS_NULLABLE | COLUMN_KEY | EXTRA          |
+-------------+------------------+-------------+------------+----------------+
| id          | int(10) unsigned | NO          | PRI        | auto_increment |
+-------------+------------------+-------------+------------+----------------+
```

## 4. Unsafe use of curl

Usage of curl is being made unsafe by adding the following options:
```
CURLOPT_SSL_VERIFYHOST => false,
CURLOPT_SSL_VERIFYPEER => false,
```

I think it's meant to make the development of the plugin easier, but it raising huge security concerns. I added a safer option in the provider, making it possible for everyone to use unsafe option, if they wishes, but set to 'true' by default for higher security.

## 5. Fix uninstall hook

With a fresh install, uninstalling blocks any future installation. The `plugin:singlesignon` `version` stays in the database.
Updated method will clean all variables.

I tried something like this but it didn't work, so I ended up doing another way.
```php
   $configurationValues = $config->getConfigurationValues('plugin:singlesignon');

   $config->deleteConfigurationValues('plugin:singlesignon', $configurationValues);
```

---

## New features

- OpenID groups support
- Enhanced security when using (php) CURL, configurable per provider
- Enhanced user first_name and last_name detection (inspired from #129)