### PR TITLE
Make public.send.php public again

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -76,6 +76,9 @@ function plugin_init_singlesignon() {
    $PLUGIN_HOOKS['menu_toadd']['singlesignon'] = [
       'config'  => Provider::class,
    ];
+
+   // Make the picture.send.php page public again.
+   Firewall::addPluginStrategyForLegacyScripts('singlesignon', '#^/front/picture.send.php$#', Firewall::STRATEGY_NO_CHECK);
 }
 
 // Get the name and the version of the plugin - Needed


### PR DESCRIPTION
GLPI 11.0.4 blocks the uploaded button picture by default if the user isn't logged in.

After this PR, the image returns an HTTP code 200:

<img width="1603" height="543" alt="image" src="https://github.com/user-attachments/assets/ed8862e9-d2e1-4676-b864-8de78a919c12" />

Without this PR, the plugin redirects to the login page because user isn't authenticated:

<img width="1916" height="438" alt="image" src="https://github.com/user-attachments/assets/d532bbdb-e42b-4a96-9099-00f4920b7f76" />