### PR TITLE
fix: Apply deletions before processing field mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 ---
+## [2.1.0](https://github.com/edgardmessias/glpi-singlesignon/releases/tag/v2.1.0) - 2026-05-25
+
+### Bug Fixes
+
+- Apply deletions before processing field mappings - ([3eea92d](https://github.com/edgardmessias/glpi-singlesignon/commit/3eea92d2790cd9dda3737a11d3cc848ec79198a1)) - eduardomozart
+
+---
 ## [2.0.2](https://github.com/edgardmessias/glpi-singlesignon/releases/tag/v2.0.2) - 2026-04-11
 
 ### Bug Fixes

--- a/src/Provider_Field.php
+++ b/src/Provider_Field.php
@@ -237,6 +237,8 @@ class Provider_Field extends CommonDBTM
             $rows = [];
         }
 
+        // First pass: apply deletions so update/insert runs against the final row set
+        // selected in the same submit (avoids stale-row side effects in one request).
         foreach ($rows as $row) {
             if (!is_array($row)) {
                 continue;
@@ -244,35 +246,51 @@ class Provider_Field extends CommonDBTM
 
             $mappingId = (int) ($row['id'] ?? 0);
             $delete = (int) ($row['_delete'] ?? 0) === 1;
-            $fieldType = (string) ($row['field_type'] ?? '');
-            $jsonpath = trim((string) ($row['jsonpath'] ?? ''));
-            $sortOrder = (int) ($row['sort_order'] ?? 0);
-            $isActive = (int) (($row['is_active'] ?? 0) ? 1 : 0);
 
             if ($mappingId > 0 && $delete) {
                 $this->deleteByCriteria([
                     'id' => $mappingId,
                     'plugin_singlesignon_providers_id' => $providerId,
                 ]);
-            } elseif (!in_array($fieldType, $types, true) || $jsonpath === '') {
-                continue;
-            } else {
-                $payload = [
-                    'plugin_singlesignon_providers_id' => $providerId,
-                    'field_type'                       => $fieldType,
-                    'jsonpath'                         => $jsonpath,
-                    'is_active'                        => $isActive,
-                    'sort_order'                       => $sortOrder,
-                ];
-
-                if ($mappingId > 0) {
-                    $payload['id'] = $mappingId;
-                    $this->update($payload);
-                    continue;
-                }
-
-                $this->add($payload);
             }
+        }
+
+        // Second pass: process remaining valid rows (not deleted) as update/insert.
+        foreach ($rows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $mappingId = (int) ($row['id'] ?? 0);
+            $delete = (int) ($row['_delete'] ?? 0) === 1;
+            if ($delete) {
+                continue;
+            }
+
+            $fieldType = (string) ($row['field_type'] ?? '');
+            $jsonpath = trim((string) ($row['jsonpath'] ?? ''));
+            $sortOrder = (int) ($row['sort_order'] ?? 0);
+            $isActive = (int) (($row['is_active'] ?? 0) ? 1 : 0);
+
+            if (!in_array($fieldType, $types, true) || $jsonpath === '') {
+                continue;
+            }
+
+            $payload = [
+                'plugin_singlesignon_providers_id' => $providerId,
+                'field_type'                       => $fieldType,
+                'jsonpath'                         => $jsonpath,
+                'is_active'                        => $isActive,
+                'sort_order'                       => $sortOrder,
+            ];
+
+            if ($mappingId > 0) {
+                $payload['id'] = $mappingId;
+                $this->update($payload);
+                continue;
+            }
+
+            $this->add($payload);
         }
 
         Session::addMessageAfterRedirect(__s('Field mappings updated.', 'singlesignon'));


### PR DESCRIPTION
Split processing into two passes: first remove mappings flagged for deletion so subsequent updates/inserts operate on the final row set, preventing stale-row side effects in a single request. Then iterate again to validate remaining rows and perform updates or inserts. Validation and payload construction were moved into the second pass; early-continue is used for deleted or invalid rows. UI message behavior unchanged.