### PR TITLE
feat(ui): Add contextual helper tooltips for login behavior configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,6 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 ---
-## [2.1.0](https://github.com/edgardmessias/glpi-singlesignon/compare/v2.0.2...v2.1.0) - 2026-05-25
-
-### Features
-
-- Added help tooltips/tips for SSO provider login behavior preferences (`IsDefault`, `SplitDomain`, and `Split Name`) - ([559c834](https://github.com/edgardmessias/glpi-singlesignon/commit/559c8342ca1ee686fd1b3500b291e1b7a3c92642)) - Eduardo Mozart de Oliveira
-
----
 ## [2.0.2](https://github.com/edgardmessias/glpi-singlesignon/releases/tag/v2.0.2) - 2026-04-11
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 ---
+## [2.1.0](https://github.com/edgardmessias/glpi-singlesignon/compare/v2.0.2...v2.1.0) - 2026-05-25
+
+### Features
+
+- Added help tooltips/tips for SSO provider login behavior preferences (`IsDefault`, `SplitDomain`, and `Split Name`) - ([559c834](https://github.com/edgardmessias/glpi-singlesignon/commit/559c8342ca1ee686fd1b3500b291e1b7a3c92642)) - Eduardo Mozart de Oliveira
+
+---
 ## [2.0.2](https://github.com/edgardmessias/glpi-singlesignon/releases/tag/v2.0.2) - 2026-04-11
 
 ### Bug Fixes

--- a/templates/provider/show_form.html.twig
+++ b/templates/provider/show_form.html.twig
@@ -39,6 +39,9 @@
 {% set _tip_custom_headers = call('nl2br', [__('One header per line (format: Header-Name: value). Supported placeholders: <token> and <access_token>. Example: api-key: <token>', 'singlesignon')]) %}
 {% set _tip_ssl_verify_host = call('nl2br', [__('Verify that the server certificate matches the hostname (recommended). Disable only for testing or self-signed certificates.', 'singlesignon')]) %}
 {% set _tip_ssl_verify_peer = call('nl2br', [__('Verify the server certificate against trusted CAs (recommended). Disable only for testing or self-signed certificates.', 'singlesignon')]) %}
+{% set _tip_is_default = call('nl2br', [__('When enabled, users who visit the login page will be automatically redirected to this provider\'s authentication page. To bypass the redirect and access the standard GLPI login form, add noAUTO=1 to the login URL.', 'singlesignon')]) %}
+{% set _tip_split_domain = call('nl2br', [__('When enabled, the domain part (everything after @) is stripped from the user\'s login name. Useful when the IdP returns an email address as the login and GLPI usernames do not include the domain.', 'singlesignon')]) %}
+{% set _tip_split_name = call('nl2br', [__('When enabled, the full name returned by the IdP is automatically split into first name and last name fields.', 'singlesignon')]) %}
 
 {% set type_on_change = 'var _value = this.options[this.selectedIndex].value; $(".sso_url").toggle(_value == "generic");' %}
 {% set field_opts = {
@@ -123,14 +126,20 @@
         <div class="hr-text my-3">{{ __('Login behavior', 'singlesignon') }}</div>
     </div>
 
-    {{ fields.dropdownYesNo('is_default', provider.fields.is_default|default(0), __('IsDefault', 'singlesignon'), field_opts) }}
+    {{ fields.dropdownYesNo('is_default', provider.fields.is_default|default(0), __('IsDefault', 'singlesignon'), {
+        helper: _tip_is_default
+    }|merge(field_opts)) }}
     {{ fields.dropdownYesNo('popup', provider.fields.popup|default(0), __('PopupAuth', 'singlesignon'), field_opts) }}
-    {{ fields.dropdownYesNo('split_domain', provider.fields.split_domain|default(0), __('SplitDomain', 'singlesignon'), field_opts) }}
+    {{ fields.dropdownYesNo('split_domain', provider.fields.split_domain|default(0), __('SplitDomain', 'singlesignon'), {
+        helper: _tip_split_domain
+    }|merge(field_opts)) }}
     {{ fields.textField('authorized_domains', provider.fields.authorized_domains|default(''), __('AuthorizedDomains', 'singlesignon'), {
         helper: _tip_domains
     }|merge(field_opts)) }}
     {{ fields.dropdownYesNo('use_email_for_login', provider.fields.use_email_for_login|default(0), __('Use Email as Login', 'singlesignon'), field_opts) }}
-    {{ fields.dropdownYesNo('split_name', provider.fields.split_name|default(0), __('Split Name', 'singlesignon'), field_opts) }}
+    {{ fields.dropdownYesNo('split_name', provider.fields.split_name|default(0), __('Split Name', 'singlesignon'), {
+        helper: _tip_split_name
+    }|merge(field_opts)) }}
 
     <div class="col-12">
         <div class="hr-text my-3">{{ __('Registration', 'singlesignon') }}</div>


### PR DESCRIPTION
## Summary
This pull request improves the SSO provider setup experience for administrators by introducing detailed, localized helper tooltips next to key **Login behavior** settings: `IsDefault`, `SplitDomain`, and `Split Name`. 

These tooltips provide clear explanations of what each setting does, why it is useful, and how to utilize or bypass its behavior (e.g. explaining the `noAUTO=1` URL bypass parameter).

---

## Key Changes

### 1. In-context Administration Tooltips (`templates/provider/show_form.html.twig`)
- **New Helper Variables**:
  - `IsDefault` (`_tip_is_default`): Informs administrators that turning this on automatically redirects standard login page visitors straight to this provider's portal, and explains how to bypass this redirect by appending `noAUTO=1` to the login URL.
  - `SplitDomain` (`_tip_split_domain`): Explains that enabling this strips the domain suffix (everything starting from the `@` symbol) from the login claim, which is ideal if the IdP sends full emails but GLPI expects domain-free usernames.
  - `SplitName` (`_tip_split_name`): Explains that the plugin will automatically split a single full name string received from the IdP into distinct GLPI first name and last name fields.
- **UI Form Integration**:
  - Merged these helper text blocks into the options of their respective `dropdownYesNo` inputs, rendering them as standard interactive help icons next to the field labels.

### 2. Release Preparation (`CHANGELOG.md`)
- Logged these tooltips and help-text additions under the upcoming `2.1.0` release section in `CHANGELOG.md`.

---

## Verification Plan

1. **Verify Tooltip Visibility**:
   - Log into the GLPI administrative panel.
   - Navigate to **Setup** > **Single Sign-On** and open your provider.
   - Scroll down to the **Login behavior** card.
   - Verify that question-mark help icons are visible next to the labels **IsDefault**, **SplitDomain**, and **Split Name**.
2. **Verify Tooltip Context**:
   - Hover over each help icon and confirm the popover tooltips render cleanly.
   - Check that all formatting (such as line breaks or code terms) displays correctly and is highly legible.