### PR TITLE
fix(ui): Gracefully check for Composer autoloader during prerequisite validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 ---
+## [2.1.0](https://github.com/edgardmessias/glpi-singlesignon/releases/tag/v2.1.0) - 2026-05-25
+
+### Bug Fixes
+
+- Check for Composer autoload in setup - ([b686ea3](https://github.com/edgardmessias/glpi-singlesignon/commit/b686ea38d78019c7017e38b99ac4f7894c01c318)) - Eduardo Mozart de Oliveira
+
+---
 ## [2.0.2](https://github.com/edgardmessias/glpi-singlesignon/releases/tag/v2.0.2) - 2026-04-11
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,6 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 ---
-## [2.1.0](https://github.com/edgardmessias/glpi-singlesignon/releases/tag/v2.1.0) - 2026-05-25
-
-### Bug Fixes
-
-- Check for Composer autoload in setup - ([b686ea3](https://github.com/edgardmessias/glpi-singlesignon/commit/b686ea38d78019c7017e38b99ac4f7894c01c318)) - Eduardo Mozart de Oliveira
-
----
 ## [2.0.2](https://github.com/edgardmessias/glpi-singlesignon/releases/tag/v2.0.2) - 2026-04-11
 
 ### Bug Fixes

--- a/setup.php
+++ b/setup.php
@@ -128,6 +128,16 @@ function plugin_singlesignon_check_prerequisites()
         return false;
     }
 
+    // Check if Composer's autoload file exists
+    if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
+        echo sprintf(
+            htmlspecialchars(__('The %1$s folder is missing. Please run %2$s inside the plugin directory, or download the official release archive.', 'singlesignon'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            '"vendor/"',
+            '"composer install --no-dev"',
+        );
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
## Summary
This pull request introduces a crucial system check to verify that Composer's autoloader (`vendor/autoload.php`) exists before permitting plugin activation in GLPI (closes https://github.com/edgardmessias/glpi-singlesignon/issues/166). 

<img width="805" height="131" alt="image" src="https://github.com/user-attachments/assets/077ea141-632e-40a2-861a-ae6bed1970ad" />

If the `vendor/` folder is missing (often the case when the plugin is cloned directly from the repository source rather than downloaded via pre-compiled release packages), the plugin blocks activation and outputs a clear, localized guidance message, preventing PHP class-not-found fatal crashes.

---

## Key Changes

### 1. Composer Autoload Validation (`setup.php`)
- **Dependency Guard**:
  - Added a `file_exists()` validation check for the path `__DIR__ . '/vendor/autoload.php'` inside `plugin_singlesignon_check_prerequisites()`.
- **Actionable User Message**:
  - If the autoloader is missing, the plugin outputs a structured and escaped warning explaining that the `"vendor/"` folder is missing.
  - Instructs administrators to either execute `composer install --no-dev` in the plugin directory or download the official, bundled release archive.
  - Returns `false` to prevent the plugin from activating, keeping GLPI stable.

### 2. Release Preparation (`CHANGELOG.md`)
- Logged this prerequisite check under the upcoming `2.1.0` release section in `CHANGELOG.md`.

---

## Verification Plan

1. **Verify Handling of Missing `vendor/` Directory**:
   - Temporarily rename the `vendor` directory inside the plugin's folder to `vendor_disabled`.
   - Open GLPI's Plugins administration panel.
   - Attempt to check prerequisites or activate the Single Sign-On plugin.
   - Verify that GLPI handles the prerequisite check gracefully, displaying the error message: *“The "vendor/" folder is missing. Please run "composer install --no-dev" inside the plugin directory...”*
   - Confirm that GLPI does not throw a PHP Fatal Error or crash.
2. **Verify Standard Activation**:
   - Rename `vendor_disabled` back to `vendor`.
   - Reload the Plugins page.
   - Confirm that prerequisite validation succeeds and the plugin can be activated normally.