### PR TITLE
fix(ui): Fix visibility toggle of generic SSO fields and resolve SSO Type accessibility warning

### DIFF
--- a/templates/provider/show_form.html.twig
+++ b/templates/provider/show_form.html.twig
@@ -197,12 +197,11 @@
         inline_add_field_html: true
     }|merge(field_opts)) }}
 
-    {% set picture_rand = random() %}
     {% if provider.fields.picture|default('') is not empty %}
-        {% set picture_field = call('Html::image', [call(['GlpiPlugin\\Singlesignon\\ToolboxPlugin', 'getPictureUrl'], [provider.fields.picture]), {style: picture_style, class: 'picture_square', id: 'picture_' ~ picture_rand}])|raw %}
+        {% set picture_field = call('Html::image', [call(['GlpiPlugin\\Singlesignon\\ToolboxPlugin', 'getPictureUrl'], [provider.fields.picture]), {style: picture_style, class: 'picture_square'}])|raw %}
         {% set picture_extra = '<label class="mb-0 d-flex justify-content-end align-items-center" style="cursor: pointer;">' ~ call('Html::getCheckbox', [{title: __('Clear'), name: '_blank_picture', class: 'mt-0'}])|raw ~ '<span class="ms-1">' ~ __('Clear')|e ~ '</span></label>' %}
     {% else %}
-        {% set picture_field = inputs.file('picture', null, {onlyimages: true, id: 'picture_' ~ picture_rand}) %}
+        {% set picture_field = inputs.file('picture', null, {onlyimages: true}) %}
         {% set picture_extra = '' %}
     {% endif %}
     {{ fields.htmlField('picture', picture_field, __('Picture'), {
@@ -210,8 +209,7 @@
         label_class: field_opts.label_class,
         input_class: field_opts.input_class,
         add_field_html: picture_extra,
-        inline_add_field_html: true,
-        rand: picture_rand
+        inline_add_field_html: true
     }) }}
     {{ fields.nullField({
         field_class: 'col-12 col-xxl-6'
@@ -233,7 +231,7 @@ $("[name=color]").on("change", function () {
     <div class="col-12 mt-2">
         <div class="hr-text my-3">{{ __('Test') }}</div>
     </div>
-    {{ fields.htmlField('callback_url', cb_link, __('Callback URL', 'singlesignon'), {full_width: true, id: 'singlesignon_callbackurl'}|merge(field_opts)) }}
+    {{ fields.htmlField('callback_url', cb_link, __('Callback URL', 'singlesignon'), {full_width: true}|merge(field_opts)) }}
 {% endif %}
 </div>
 

--- a/templates/provider/show_form.html.twig
+++ b/templates/provider/show_form.html.twig
@@ -43,7 +43,7 @@
 {% set _tip_split_domain = call('nl2br', [__('When enabled, the domain part (everything after @) is stripped from the user\'s login name. Useful when the IdP returns an email address as the login and GLPI usernames do not include the domain.', 'singlesignon')]) %}
 {% set _tip_split_name = call('nl2br', [__('When enabled, the full name returned by the IdP is automatically split into first name and last name fields.', 'singlesignon')]) %}
 
-{% set type_on_change = 'var _value = this.options[this.selectedIndex].value; $(".sso_url").toggle(_value == "generic");' %}
+{% set type_on_change = 'var _value = this.options[this.selectedIndex].value; $(".sso_url").toggleClass("d-none", _value != "generic");' %}
 {% set field_opts = {
     align_label_right: true,
     field_class: 'col-12 col-xxl-6',
@@ -69,15 +69,17 @@
         enable_fileupload: false
     }|merge(field_opts)) }}
 
+    {% set type_rand = random() %}
     {% set type_field %}
         {{ call(['GlpiPlugin\\Singlesignon\\Provider', 'dropdownType'], ['type', {
             value: provider.fields.type|default('generic'),
             on_change: type_on_change,
             width: '100%',
-            display: false
+            display: false,
+            rand: type_rand
         }])|raw }}
     {% endset %}
-    {{ fields.htmlField('type', type_field, __('SSO Type', 'singlesignon'), field_opts) }}
+    {{ fields.htmlField('type', type_field, __('SSO Type', 'singlesignon'), field_opts|merge({id: 'dropdown_type' ~ type_rand})) }}
     {{ fields.dropdownYesNo('is_active', provider.fields.is_active|default(0), __('Active'), field_opts) }}
 
     {{ fields.textField('client_id', provider.fields.client_id|default(''), __('Client ID', 'singlesignon'), field_opts) }}
@@ -195,11 +197,12 @@
         inline_add_field_html: true
     }|merge(field_opts)) }}
 
+    {% set picture_rand = random() %}
     {% if provider.fields.picture|default('') is not empty %}
-        {% set picture_field = call('Html::image', [call(['GlpiPlugin\\Singlesignon\\ToolboxPlugin', 'getPictureUrl'], [provider.fields.picture]), {style: picture_style, class: 'picture_square'}])|raw %}
+        {% set picture_field = call('Html::image', [call(['GlpiPlugin\\Singlesignon\\ToolboxPlugin', 'getPictureUrl'], [provider.fields.picture]), {style: picture_style, class: 'picture_square', id: 'picture_' ~ picture_rand}])|raw %}
         {% set picture_extra = '<label class="mb-0 d-flex justify-content-end align-items-center" style="cursor: pointer;">' ~ call('Html::getCheckbox', [{title: __('Clear'), name: '_blank_picture', class: 'mt-0'}])|raw ~ '<span class="ms-1">' ~ __('Clear')|e ~ '</span></label>' %}
     {% else %}
-        {% set picture_field = inputs.file('picture', null, {onlyimages: true}) %}
+        {% set picture_field = inputs.file('picture', null, {onlyimages: true, id: 'picture_' ~ picture_rand}) %}
         {% set picture_extra = '' %}
     {% endif %}
     {{ fields.htmlField('picture', picture_field, __('Picture'), {
@@ -207,7 +210,8 @@
         label_class: field_opts.label_class,
         input_class: field_opts.input_class,
         add_field_html: picture_extra,
-        inline_add_field_html: true
+        inline_add_field_html: true,
+        rand: picture_rand
     }) }}
     {{ fields.nullField({
         field_class: 'col-12 col-xxl-6'
@@ -229,7 +233,7 @@ $("[name=color]").on("change", function () {
     <div class="col-12 mt-2">
         <div class="hr-text my-3">{{ __('Test') }}</div>
     </div>
-    {{ fields.htmlField('callback_url', cb_link, __('Callback URL', 'singlesignon'), {full_width: true}|merge(field_opts)) }}
+    {{ fields.htmlField('callback_url', cb_link, __('Callback URL', 'singlesignon'), {full_width: true, id: 'singlesignon_callbackurl'}|merge(field_opts)) }}
 {% endif %}
 </div>
 


### PR DESCRIPTION
### Description
This PR addresses two UI and accessibility issues in the Provider configuration form (`show_form.html.twig`):
1. **Visibility Toggle Fix for Generic Fields:**
   Previously, when changing the "SSO Type" to "Generic", the form used jQuery's `.toggle()` which added an inline `display: block` style. This conflicted with the parent `div` that had Bootstrap's `d-none` class, causing the generic fields to remain hidden. This PR refactors the javascript logic to use `.toggleClass("d-none", _value != "generic");` so it correctly manipulates the class tree instead of overriding inline styles.
2. **Accessibility (Violating Node) Fix:**
   The `SSO Type` field was throwing a "Violating node" (Incorrect use of `<label for=FORM_ELEMENT>`) warning in the browser console. This occurred because the `htmlField` macro generated a label `for` attribute that didn't match the internal ID generated by the native GLPI dropdown. We fixed this by manually generating a `rand` variable and synchronously passing it to both the `dropdownType` function and the `htmlField` label, ensuring perfect linking between the label and the select element.
### Motivation and Context
- Fixes the bug where "Generic" specific fields (like OAuth URLs) would not show up when actively switching provider types in the interface.
- Improves form HTML accessibility and clears browser console warnings.
### How Has This Been Tested?
- Toggled the SSO Type between predefined providers (e.g. Azure) and Generic to confirm the URL fields correctly disappear and reappear.
- Checked the browser accessibility console to ensure the "Violating node" warning for the SSO Type field is fully resolved without breaking GLPI's native macro structure.