### PR TITLE
Fix REMOTE_USER fallback and missing SSO dummy field

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -2097,8 +2097,13 @@ class Provider extends CommonDBTM
             break;
         }
 
+        // Prevent GLPI fallback auth from picking up an existing REMOTE_USER (e.g. from Basic Auth)
+        $original_remote_user = $_SERVER['REMOTE_USER'] ?? null;
+        $_SERVER['REMOTE_USER'] = $user->fields['name'];
+
         // Force to run RuleRightCollection::processAllRules in User::getFromSSO by setting a dummy SSO field
         $CFG_GLPI['singlesignon_ssofield'] = 'singlesignon_ssofield_dummy';
+        $_SERVER['singlesignon_ssofield_dummy'] = $user->fields['name'];
         if (isset($user->input['_singlesignon_email'])) {
             $CFG_GLPI['email1_ssofield'] = 'singlesignon_ssofield_email1';
             $_SERVER['singlesignon_ssofield_email1'] = $user->input['_singlesignon_email'];
@@ -2121,6 +2126,13 @@ class Provider extends CommonDBTM
         if ($sso_variable_name !== '') {
             unset($_SERVER[$sso_variable_name]);
         }
+
+        if ($original_remote_user !== null) {
+            $_SERVER['REMOTE_USER'] = $original_remote_user;
+        } else {
+            unset($_SERVER['REMOTE_USER']);
+        }
+        unset($_SERVER['singlesignon_ssofield_dummy']);
 
         if (!$authResult) {
             $userId = (int) $user->fields['id'];


### PR DESCRIPTION
# Description
This PR addresses two silent bugs in the SSO login pipeline discovered during the investigation of #164. 

While the exact symptoms reported in #164 were likely caused by the administrator accidentally linking their Keycloak test account to their active `glpi` session (which was bypassed by changing the mapping), this PR prevents GLPI from falling back to incorrect out-of-band server variables and fixes the execution of authorization rules for new users.

### Root Cause & Fixes

1. **Incorrect `$_SERVER['REMOTE_USER']` Fallback:** 
   GLPI's core alternate authentication (`Auth::getAlternateAuthSystemsUser()`) checks `$_SERVER['REMOTE_USER']` as a fallback if `glpi_ssovariables` is not explicitly configured or populated. If an administrator is running GLPI behind a reverse proxy or has Basic Auth enabled on the web server, this server-level header persists during the SSO redirect. Because the plugin did not safely overwrite `REMOTE_USER`, GLPI's authentication pipeline could mistakenly consume the pre-existing server header instead of the mapped Keycloak user, leading to incorrect logins (e.g., as the `glpi` superuser).
   **Fix:** Explicitly set `$_SERVER['REMOTE_USER'] = $user->fields['name']` alongside the existing SSO variables to ensure GLPI always matches the newly provisioned Keycloak user. We also ensure that the original `REMOTE_USER` variable is properly restored or unset during cleanup.

2. **Failed Rules Processing (Missing Profile Assignment):** 
   To apply authorization rules via GLPI's engine, the plugin assigns a dummy SSO field configuration (`$CFG_GLPI['singlesignon_ssofield'] = 'singlesignon_ssofield_dummy'`). However, it never actually populated the corresponding `$_SERVER` variable. As a result, `User::getFromSSO()` silently failed to locate the user context, aborting the rules engine entirely and preventing the assignment of the intended self-service profiles.
   **Fix:** We now properly populate `$_SERVER['singlesignon_ssofield_dummy'] = $user->fields['name']` prior to executing the `Auth::login` pipeline.

### Changes Made
- Added `$_SERVER['REMOTE_USER']` population and cleanup in `Provider::performGlpiLogin()`.
- Added `$_SERVER['singlesignon_ssofield_dummy']` population and cleanup in `Provider::performGlpiLogin()`.