### PR TITLE
Fix: avoid linking user account when testing OAuth provider

### DIFF
--- a/front/callback.php
+++ b/front/callback.php
@@ -62,6 +62,16 @@ if (!$signon_provider->fields['is_active']) {
     throw $exception;
 }
 
+// If this is the start of the flow (no code) and the test cookie is present, save the test flag to the session
+// so it survives cross-site redirects where the cookie might be dropped.
+if (!isset($_GET['code'])) {
+    if (isset($_COOKIE['glpi_singlesignon_test']) && $_COOKIE['glpi_singlesignon_test'] === '1') {
+        $_SESSION['glpi_singlesignon_test'] = true;
+    } else {
+        unset($_SESSION['glpi_singlesignon_test']);
+    }
+}
+
 /**
  * Handles the OAuth authorization callback from the identity provider.
  * This function validates the CSRF (state) token, extracts the authorization code,
@@ -72,14 +82,20 @@ if (!$signon_provider->fields['is_active']) {
 $signon_provider->checkAuthorization();
 
 /**
- * The "glpi_singlesignon_test" cookie is used to signal that this callback request is a test for the Single Sign-On (SSO) integration.
+ * The "glpi_singlesignon_test" flag is used to signal that this callback request is a test for the Single Sign-On (SSO) integration.
  * When set (by the test button in the provider configuration UI), this triggers debug output for developers or administrators
  * so they can inspect the SSO flow and returned data without performing an actual login.
- * The cookie is deleted after use to avoid repeated debug output.
+ * The flag is deleted after use to avoid repeated debug output.
  */
-$test_cookie = isset($_COOKIE['glpi_singlesignon_test']) && $_COOKIE['glpi_singlesignon_test'] === '1';
+$test_cookie = false;
+if (isset($_COOKIE['glpi_singlesignon_test']) && $_COOKIE['glpi_singlesignon_test'] === '1') {
+    $test_cookie = true;
+} elseif (isset($_SESSION['glpi_singlesignon_test']) && $_SESSION['glpi_singlesignon_test'] === true) {
+    $test_cookie = true;
+}
 
 if ($test_cookie) {
+    unset($_SESSION['glpi_singlesignon_test']);
     setcookie('glpi_singlesignon_test', '', [
         'expires' => time() - 3600,
         'path' => '/',


### PR DESCRIPTION
### Description
Fixes an issue where testing an OAuth authentication provider inadvertently linked the current administrator's GLPI account to the testing OAuth identity.

The issue occurred because modern browsers often drop the `glpi_singlesignon_test` cookie (which uses `SameSite=Lax`) during cross-site redirects (e.g., when returning from the OAuth provider). Without this cookie, the callback script treated the test run as a normal authentication attempt, and since the admin was already logged in, it bypassed normal login logic and proceeded to link the accounts.

### Changes Made
- Updated `front/callback.php` to persist the test flag into the `$_SESSION` *before* initiating the OAuth redirect.
- The callback script now checks the session state instead of relying solely on the cookie when the user returns from the provider, ensuring the test completes correctly and safely without linking the account.
- Handled edge cases by proactively clearing the test session flag during regular login attempts to prevent previous aborted tests from affecting actual logins.

Closes #164