### PR TITLE
Fix LinkedIn typo in auth provider labels

### DIFF
--- a/locales/de_DE.po
+++ b/locales/de_DE.po
@@ -528,8 +528,8 @@ msgid "Instagram"
 msgstr "Instagram"
 
 #: \src\Provider.php:586
-msgid "LinkdeIn"
-msgstr "LinkdeIn"
+msgid "LinkedIn"
+msgstr "LinkedIn"
 
 #: \src\Provider.php:761
 msgid "SSO login may fail due to CSRF validation."

--- a/locales/en_GB.po
+++ b/locales/en_GB.po
@@ -510,8 +510,8 @@ msgid "Instagram"
 msgstr "Instagram"
 
 #: \src\Provider.php:586
-msgid "LinkdeIn"
-msgstr "LinkdeIn"
+msgid "LinkedIn"
+msgstr "LinkedIn"
 
 #: \src\Provider.php:761
 msgid "SSO login may fail due to CSRF validation."

--- a/locales/es_CO.po
+++ b/locales/es_CO.po
@@ -525,7 +525,7 @@ msgid "Instagram"
 msgstr "Instagram"
 
 #: \src\Provider.php:586
-msgid "LinkdeIn"
+msgid "LinkedIn"
 msgstr "LinkedIn"
 
 #: \src\Provider.php:761

--- a/locales/es_ES.po
+++ b/locales/es_ES.po
@@ -529,7 +529,7 @@ msgid "Instagram"
 msgstr "Instagram"
 
 #: \src\Provider.php:586
-msgid "LinkdeIn"
+msgid "LinkedIn"
 msgstr "LinkedIn"
 
 #: \src\Provider.php:761

--- a/locales/fr_FR.po
+++ b/locales/fr_FR.po
@@ -531,8 +531,8 @@ msgid "Instagram"
 msgstr "Instagram"
 
 #: \src\Provider.php:586
-msgid "LinkdeIn"
-msgstr "LinkdeIn"
+msgid "LinkedIn"
+msgstr "LinkedIn"
 
 #: \src\Provider.php:761
 msgid "SSO login may fail due to CSRF validation."

--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -521,8 +521,8 @@ msgid "Instagram"
 msgstr "Instagram"
 
 #: \src\Provider.php:586
-msgid "LinkdeIn"
-msgstr "LinkdeIn"
+msgid "LinkedIn"
+msgstr "LinkedIn"
 
 #: \src\Provider.php:761
 msgid "SSO login may fail due to CSRF validation."

--- a/locales/singlesignon.pot
+++ b/locales/singlesignon.pot
@@ -485,7 +485,7 @@ msgid "Instagram"
 msgstr ""
 
 #: \src\Provider.php:586
-msgid "LinkdeIn"
+msgid "LinkedIn"
 msgstr ""
 
 #: \src\Provider.php:761

--- a/locales/tr_TR.po
+++ b/locales/tr_TR.po
@@ -526,8 +526,8 @@ msgid "Instagram"
 msgstr "Instagram"
 
 #: \src\Provider.php:586
-msgid "LinkdeIn"
-msgstr "LinkdeIn"
+msgid "LinkedIn"
+msgstr "LinkedIn"
 
 #: \src\Provider.php:761
 msgid "SSO login may fail due to CSRF validation."

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -655,7 +655,7 @@ class Provider extends CommonDBTM
         $options['github'] = __('GitHub', 'singlesignon');
         $options['google'] = __('Google', 'singlesignon');
         $options['instagram'] = __('Instagram', 'singlesignon');
-        $options['linkedin'] = __('LinkdeIn', 'singlesignon');
+        $options['linkedin'] = __('LinkedIn', 'singlesignon');
 
         return $options;
     }


### PR DESCRIPTION
Corrects the misspelled "LinkdeIn" string to "LinkedIn" in `src/Provider.php` and updates the extracted translation template and locale `.po` files to keep i18n keys consistent.