### PR TITLE
feat: Refactor SSO Field Mappings to show Fallbacks as Read-Only

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -33,6 +33,30 @@
             {"field_type": "fullname", "jsonpath": "$.name", "is_active": 1, "sort_order": 40}
         ]
     },
+    "generic": {
+        "field_mappings": [
+            {"field_type": "id", "jsonpath": "$.id", "is_active": 1, "sort_order": 10},
+            {"field_type": "id", "jsonpath": "$.username", "is_active": 1, "sort_order": 20},
+            {"field_type": "id", "jsonpath": "$.sub", "is_active": 1, "sort_order": 30},
+            {"field_type": "email", "jsonpath": "$.email", "is_active": 1, "sort_order": 40},
+            {"field_type": "email", "jsonpath": "$['e-mail']", "is_active": 1, "sort_order": 50},
+            {"field_type": "email", "jsonpath": "$['email-address']", "is_active": 1, "sort_order": 60},
+            {"field_type": "email", "jsonpath": "$.mail", "is_active": 1, "sort_order": 70},
+            {"field_type": "email", "jsonpath": "$.userPrincipalName", "is_active": 1, "sort_order": 75},
+            {"field_type": "username", "jsonpath": "$.userPrincipalName", "is_active": 1, "sort_order": 80},
+            {"field_type": "username", "jsonpath": "$.login", "is_active": 1, "sort_order": 90},
+            {"field_type": "username", "jsonpath": "$.username", "is_active": 1, "sort_order": 100},
+            {"field_type": "username", "jsonpath": "$.id", "is_active": 1, "sort_order": 110},
+            {"field_type": "username", "jsonpath": "$.name", "is_active": 1, "sort_order": 120},
+            {"field_type": "username", "jsonpath": "$.displayName", "is_active": 1, "sort_order": 130},
+            {"field_type": "firstname", "jsonpath": "$.givenName", "is_active": 1, "sort_order": 135},
+            {"field_type": "lastname", "jsonpath": "$.surname", "is_active": 1, "sort_order": 136},
+            {"field_type": "fullname", "jsonpath": "$.displayName", "is_active": 1, "sort_order": 137},
+            {"field_type": "avatar_url", "jsonpath": "$.picture", "is_active": 1, "sort_order": 140},
+            {"field_type": "roles", "jsonpath": "$.roles", "is_active": 1, "sort_order": 150},
+            {"field_type": "roles", "jsonpath": "$.groups", "is_active": 1, "sort_order": 160}
+        ]
+    },
     "github": {
         "url_authorize": "https://github.com/login/oauth/authorize",
         "url_access_token": "https://github.com/login/oauth/access_token",

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -221,33 +221,7 @@ class Provider extends CommonDBTM
         return $this->prepareInput($input);
     }
 
-    public function post_addItem()
-    {
-        if (($this->fields['type'] ?? '') !== 'generic') {
-            return;
-        }
 
-        $providerId = (int) ($this->fields['id'] ?? 0);
-        if ($providerId <= 0) {
-            return;
-        }
-
-        $existing = Provider_Field::getMappingsForProvider($providerId);
-        if ($existing !== []) {
-            return;
-        }
-
-        $mapping = new Provider_Field();
-        foreach (Provider_Field::getDefaultMappings('generic') as $default) {
-            $mapping->add([
-                'plugin_singlesignon_providers_id' => $providerId,
-                'field_type'                       => $default['field_type'],
-                'jsonpath'                         => $default['jsonpath'],
-                'is_active'                        => (int) $default['is_active'],
-                'sort_order'                       => (int) $default['sort_order'],
-            ]);
-        }
-    }
 
     public function cleanDBonPurge()
     {

--- a/src/Provider_Field.php
+++ b/src/Provider_Field.php
@@ -143,41 +143,9 @@ class Provider_Field extends CommonDBTM
             ];
         }
 
-        if ($normalized === [] && $providerType === 'generic') {
-            return self::getGenericDefaultMappings();
-        }
-
         return $normalized;
     }
 
-    /**
-     * @return list<array{field_type: string, jsonpath: string, is_active: int, sort_order: int}>
-     */
-    private static function getGenericDefaultMappings(): array
-    {
-        return [
-            ['field_type' => 'id', 'jsonpath' => '$.id', 'is_active' => 1, 'sort_order' => 10],
-            ['field_type' => 'id', 'jsonpath' => '$.username', 'is_active' => 1, 'sort_order' => 20],
-            ['field_type' => 'id', 'jsonpath' => '$.sub', 'is_active' => 1, 'sort_order' => 30],
-            ['field_type' => 'email', 'jsonpath' => '$.email', 'is_active' => 1, 'sort_order' => 40],
-            ['field_type' => 'email', 'jsonpath' => '$[\'e-mail\']', 'is_active' => 1, 'sort_order' => 50],
-            ['field_type' => 'email', 'jsonpath' => '$[\'email-address\']', 'is_active' => 1, 'sort_order' => 60],
-            ['field_type' => 'email', 'jsonpath' => '$.mail', 'is_active' => 1, 'sort_order' => 70],
-            ['field_type' => 'email', 'jsonpath' => '$.userPrincipalName', 'is_active' => 1, 'sort_order' => 75],
-            ['field_type' => 'username', 'jsonpath' => '$.userPrincipalName', 'is_active' => 1, 'sort_order' => 80],
-            ['field_type' => 'username', 'jsonpath' => '$.login', 'is_active' => 1, 'sort_order' => 90],
-            ['field_type' => 'username', 'jsonpath' => '$.username', 'is_active' => 1, 'sort_order' => 100],
-            ['field_type' => 'username', 'jsonpath' => '$.id', 'is_active' => 1, 'sort_order' => 110],
-            ['field_type' => 'username', 'jsonpath' => '$.name', 'is_active' => 1, 'sort_order' => 120],
-            ['field_type' => 'username', 'jsonpath' => '$.displayName', 'is_active' => 1, 'sort_order' => 130],
-            ['field_type' => 'firstname', 'jsonpath' => '$.givenName', 'is_active' => 1, 'sort_order' => 135],
-            ['field_type' => 'lastname', 'jsonpath' => '$.surname', 'is_active' => 1, 'sort_order' => 136],
-            ['field_type' => 'fullname', 'jsonpath' => '$.displayName', 'is_active' => 1, 'sort_order' => 137],
-            ['field_type' => 'avatar_url', 'jsonpath' => '$.picture', 'is_active' => 1, 'sort_order' => 140],
-            ['field_type' => 'roles', 'jsonpath' => '$.roles', 'is_active' => 1, 'sort_order' => 150],
-            ['field_type' => 'roles', 'jsonpath' => '$.groups', 'is_active' => 1, 'sort_order' => 160],
-        ];
-    }
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
@@ -221,12 +189,19 @@ class Provider_Field extends CommonDBTM
         }
 
         $mappings = static::getMappingsForProvider((int) $provider->getID());
+
+        $all_defaults = [];
+        foreach (array_keys(Provider::getTypes()) as $type) {
+            $all_defaults[$type] = static::getDefaultMappings($type);
+        }
+
         echo TemplateRenderer::getInstance()->render('@singlesignon/provider/show_field_mappings_tab.html.twig', [
-            'provider'    => $provider,
-            'provider_id' => (int) $provider->getID(),
-            'mappings'    => $mappings,
-            'field_types' => static::getFieldTypes(),
-            'form_action' => ToolboxPlugin::getBaseURL() . Plugin::getPhpDir('singlesignon', false) . '/front/provider_field.form.php',
+            'provider'     => $provider,
+            'provider_id'  => (int) $provider->getID(),
+            'mappings'     => $mappings,
+            'all_defaults' => $all_defaults,
+            'field_types'  => static::getFieldTypes(),
+            'form_action'  => ToolboxPlugin::getBaseURL() . Plugin::getPhpDir('singlesignon', false) . '/front/provider_field.form.php',
         ]);
     }
 

--- a/templates/provider/show_field_mappings_tab.html.twig
+++ b/templates/provider/show_field_mappings_tab.html.twig
@@ -40,7 +40,7 @@
             <p class="text-muted">
                 {{ __('Configure JSONPath rules used to extract fields from Resource Owner response.', 'singlesignon') }}
             </p>
-            <table class="table table-striped table-hover align-middle"
+            <table class="table table-hover align-middle"
                    id="sso-field-mappings-table"
                    data-restore-label="{{ __('Restore') }}">
                 <thead>
@@ -53,53 +53,18 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for map in rows %}
-                        {% set is_saved = (map.id|default(0)) > 0 %}
-                        <tr data-row data-saved="{{ is_saved ? '1' : '0' }}">
-                            <td>
-                                <input type="hidden" name="_field_mappings[{{ loop.index0 }}][id]" value="{{ map.id|default(0) }}"/>
-                                {% if is_saved %}
-                                    <input type="hidden" class="sso-delete-flag" name="_field_mappings[{{ loop.index0 }}][_delete]" value="0"/>
-                                {% endif %}
-                                <select class="form-select" name="_field_mappings[{{ loop.index0 }}][field_type]">
-                                    {% for key, label in field_types %}
-                                        <option value="{{ key }}" {% if key == map.field_type %}selected{% endif %}>{{ label }}</option>
-                                    {% endfor %}
-                                </select>
-                            </td>
-                            <td>
-                                <input type="text"
-                                       class="form-control"
-                                       name="_field_mappings[{{ loop.index0 }}][jsonpath]"
-                                       value="{{ map.jsonpath|default('') }}"
-                                       placeholder="$.id"/>
-                            </td>
-                            <td class="text-center">
-                                <input type="checkbox"
-                                       class="form-check-input"
-                                       name="_field_mappings[{{ loop.index0 }}][is_active]"
-                                       value="1"
-                                       {% if map.is_active|default(1) %}checked{% endif %}/>
-                            </td>
-                            <td class="text-center">
-                                <input type="number"
-                                       class="form-control text-end"
-                                       style="max-width: 100px; margin: 0 auto;"
-                                       name="_field_mappings[{{ loop.index0 }}][sort_order]"
-                                       value="{{ map.sort_order|default(10) }}"/>
-                            </td>
-                            <td class="text-center">
-                                <button type="button" class="btn btn-outline-danger btn-sm" data-remove-row>
-                                    <i class="ti ti-trash"></i> {{ __('Remove') }}
-                                </button>
-                            </td>
-                        </tr>
-                    {% endfor %}
                 </tbody>
             </table>
-            <button type="button" id="sso-add-mapping-row" class="btn btn-outline-secondary">
-                <i class="ti ti-plus"></i> {{ __('Add') }}
-            </button>
+            <div class="mt-3">
+                <span class="d-flex gap-2">
+                    <button type="button" id="sso-add-mapping-row" class="btn btn-outline-secondary">
+                        <i class="ti ti-plus"></i> <span>{{ __('Add') }}</span>
+                    </button>
+                    <button type="button" id="sso-reset-mappings-btn" class="btn btn-ghost-danger" data-bs-toggle="modal" data-bs-target="#reset_mappings_modal" {% if provider.fields.type == 'generic' %}style="display: none;"{% endif %}>
+                        <span>{{ __('Reset to defaults') }}</span>
+                    </button>
+                </span>
+            </div>
         </div>
         <div class="card-footer text-end">
             <button type="submit" name="update_mappings" class="btn btn-primary">
@@ -110,49 +75,152 @@
     </div>
 </form>
 
+{% include 'components/danger_modal.html.twig' with {
+   'modal_id': 'reset_mappings_modal',
+   'title': __('Are you sure?'),
+   'content': __('Are you sure you want to reset field mappings to the defaults?', 'singlesignon'),
+   'confirm_btn': '<button type="button" id="confirm_reset_mappings_btn" class="btn btn-danger w-100" data-bs-dismiss="modal">' ~ _x('button', 'Confirm') ~ '</button>'
+} %}
+
 <script type="text/javascript">
 (() => {
     const table = document.getElementById('sso-field-mappings-table');
     const addBtn = document.getElementById('sso-add-mapping-row');
-    if (!table || !addBtn) {
+    const resetBtn = document.getElementById('sso-reset-mappings-btn');
+    const confirmResetBtn = document.getElementById('confirm_reset_mappings_btn');
+    const tbody = table ? table.querySelector('tbody') : null;
+    if (!table || !addBtn || !tbody) {
         return;
     }
 
     const types = {{ field_types|json_encode|raw }};
+    const allDefaults = {{ all_defaults|json_encode|raw }};
+    const initialMappings = {{ mappings|json_encode|raw }};
+    const removeLabel = {{ __('Remove')|e('js')|json_encode|raw }};
+    const initialType = {{ provider.fields.type|json_encode|raw }};
 
-    const buildOptions = () => Object.entries(types)
-        .map(([key, label]) => `<option value="${key}">${label}</option>`)
+    const buildOptions = (selectedKey = '') => Object.entries(types)
+        .map(([key, label]) => `<option value="${key}" ${key === selectedKey ? 'selected' : ''}>${label}</option>`)
         .join('');
 
-    const nextIndex = () => table.querySelectorAll('tbody tr[data-row]').length;
+    const nextIndex = () => table.querySelectorAll('tbody tr:not([data-readonly="1"])').length;
 
-    addBtn.addEventListener('click', () => {
+
+
+    const addCustomRow = (map = null, isSaved = false) => {
         const idx = nextIndex();
         const tr = document.createElement('tr');
         tr.setAttribute('data-row', '');
-        tr.setAttribute('data-saved', '0');
+        tr.setAttribute('data-saved', isSaved ? '1' : '0');
+        
+        const mapId = map ? (map.id || 0) : 0;
+        const fieldType = map ? map.field_type : 'id';
+        const jsonPath = map ? (map.jsonpath || '') : '';
+        const isActive = map ? (map.is_active == 1) : true;
+        const sortOrder = map ? (map.sort_order || ((idx + 1) * 10)) : ((idx + 1) * 10);
+        
+        let idInputs = `<input type="hidden" name="_field_mappings[${idx}][id]" value="${mapId}"/>`;
+        if (isSaved) {
+            idInputs += `<input type="hidden" class="sso-delete-flag" name="_field_mappings[${idx}][_delete]" value="0"/>`;
+        }
+
         tr.innerHTML = `
             <td>
-                <input type="hidden" name="_field_mappings[${idx}][id]" value="0"/>
-                <select class="form-select" name="_field_mappings[${idx}][field_type]">${buildOptions()}</select>
+                ${idInputs}
+                <select class="form-select" name="_field_mappings[${idx}][field_type]">${buildOptions(fieldType)}</select>
             </td>
             <td>
-                <input type="text" class="form-control" name="_field_mappings[${idx}][jsonpath]" placeholder="$.id"/>
+                <input type="text" class="form-control" name="_field_mappings[${idx}][jsonpath]" value="${jsonPath}" placeholder="$.id"/>
             </td>
             <td class="text-center">
-                <input type="checkbox" class="form-check-input" name="_field_mappings[${idx}][is_active]" value="1" checked/>
+                <input type="checkbox" class="form-check-input" name="_field_mappings[${idx}][is_active]" value="1" ${isActive ? 'checked' : ''}/>
             </td>
             <td class="text-center">
-                <input type="number" class="form-control text-end" style="max-width: 100px; margin: 0 auto;" name="_field_mappings[${idx}][sort_order]" value="${(idx + 1) * 10}"/>
+                <input type="number" class="form-control text-end" style="max-width: 100px; margin: 0 auto;" name="_field_mappings[${idx}][sort_order]" value="${sortOrder}"/>
             </td>
             <td class="text-center">
                 <button type="button" class="btn btn-outline-danger btn-sm" data-remove-row>
-                    <i class="ti ti-trash"></i> {{ __('Remove')|e('js') }}
+                    <i class="ti ti-trash"></i> ${removeLabel}
                 </button>
             </td>
         `;
-        table.querySelector('tbody')?.appendChild(tr);
+        tbody.appendChild(tr);
+        return tr;
+    };
+
+    const loadDefaults = (type) => {
+        // Remove existing read-only rows
+        tbody.querySelectorAll('tr[data-readonly="1"]').forEach(tr => tr.remove());
+        
+        const defaults = allDefaults[type] || [];
+        defaults.forEach(map => {
+            const tr = document.createElement('tr');
+            tr.setAttribute('data-readonly', '1');
+            tr.classList.add('bg-light', 'text-muted');
+            tr.innerHTML = `
+                <td>
+                    <select class="form-select" disabled>${buildOptions(map.field_type)}</select>
+                </td>
+                <td>
+                    <input type="text" class="form-control" value="${map.jsonpath || ''}" disabled/>
+                </td>
+                <td class="text-center">
+                    <input type="checkbox" class="form-check-input" value="1" disabled ${map.is_active ? 'checked' : ''} style="background-color: var(--tblr-secondary); border-color: var(--tblr-secondary);"/>
+                </td>
+                <td class="text-center">
+                    <input type="number" class="form-control text-end" style="max-width: 100px; margin: 0 auto;" value="${map.sort_order || 10}" disabled/>
+                </td>
+                <td class="text-center">
+                    <span class="badge" style="background-color: var(--glpi-badge-bg);" title="{{ __('Read-only fallback', 'singlesignon') }}"><i class="ti ti-lock"></i></span>
+                </td>
+            `;
+            tbody.appendChild(tr);
+        });
+    };
+
+    const init = () => {
+        tbody.innerHTML = '';
+        if (initialMappings && initialMappings.length > 0) {
+            initialMappings.forEach(map => {
+                addCustomRow(map, true);
+            });
+        }
+        loadDefaults(initialType);
+    };
+
+    addBtn.addEventListener('click', () => {
+        addCustomRow(null, false);
     });
+
+    if (confirmResetBtn) {
+        confirmResetBtn.addEventListener('click', () => {
+            // Remove all custom overrides
+            const customRows = tbody.querySelectorAll('tr:not([data-readonly="1"])');
+            customRows.forEach(tr => {
+                if (tr.getAttribute('data-saved') === '1') {
+                    const deleteFlag = tr.querySelector('.sso-delete-flag');
+                    if (deleteFlag) deleteFlag.value = '1';
+                    tr.style.display = 'none';
+                } else {
+                    tr.remove();
+                }
+            });
+        });
+    }
+
+    $(document).on('change', 'select[name="type"]', function() {
+        const newType = $(this).val();
+        if (newType === 'generic') {
+            if (resetBtn) resetBtn.style.display = 'none';
+        } else {
+            if (resetBtn) resetBtn.style.display = '';
+        }
+        loadDefaults(newType);
+    });
+
+    // Run init
+    init();
+
 })();
 </script>
 


### PR DESCRIPTION
## Description
This PR introduces a significant architectural shift in how SSO field mappings and fallback defaults are handled, resulting in a cleaner database and a much more intuitive UI for users.
Previously, default mappings (such as those for the generic provider) were being saved directly to the database upon provider creation, causing unnecessary database clutter and making it harder to roll out updates to fallback values.
### Backend Changes
- **Stopped Persisting Defaults:** Removed the `post_addItem` hook. Default field mappings are no longer written to the database. The database now exclusively stores true user-defined custom overrides.
- **Generic Provider Consistency:** Removed the hardcoded `getGenericDefaultMappings()` method from PHP. The `generic` fallback values have been moved directly into `providers.json` (alphabetically organized), ensuring the generic provider behaves exactly like Azure, Google, and others.
### Frontend (UI) Enhancements
- **Visual Fallback Chain:** The Field Mappings tab now dynamically renders the default `providers.json` mappings as visually distinct, read-only rows (featuring disabled inputs and lock icons). Custom overrides are displayed alongside them to clearly illustrate the fallback chain. This makes it much easier for the user to understand exactly which values the plugin is using as a fallback, as this information was completely hidden from the UI previously.
- **Styling Tweaks:** Removed table striping for a cleaner look, specifically because the default table stripes used the same color as the new read-only item rows, which created visual confusion.
<img width="1248" height="647" alt="image" src="https://github.com/user-attachments/assets/dcec41fb-fe71-4eca-a656-c4bc142af487" />