### PR TITLE
fix(ui): Use native get_plugin_web_dir Twig function for public assets

### DIFF
--- a/src/ToolboxPlugin.php
+++ b/src/ToolboxPlugin.php
@@ -175,14 +175,6 @@ class ToolboxPlugin
         return self::getBaseURL() . Plugin::getPhpDir("singlesignon", false) . '/front/picture.send.php?path=' . $path;
     }
 
-    public static function getPublicAssetUrl(string $path): string
-    {
-        return self::getBaseURL()
-            . Plugin::getPhpDir('singlesignon', false)
-            . '/public/'
-            . ltrim($path, '/');
-    }
-
     public static function savePicture($src, $uniq_prefix = "")
     {
 

--- a/templates/provider/callback_test_result.html.twig
+++ b/templates/provider/callback_test_result.html.twig
@@ -212,4 +212,4 @@
 </div>
 
 <textarea id="sso-copy-all-source" class="d-none">{{ copy_payload }}</textarea>
-<script type="text/javascript" src="{{ call(['GlpiPlugin\\Singlesignon\\ToolboxPlugin', 'getPublicAssetUrl'], ['js/callback-test-result.js']) }}"></script>
+<script type="text/javascript" src="{{ get_plugin_web_dir('singlesignon') }}/public/js/callback-test-result.js"></script>

--- a/templates/provider/show_field_mappings_tab.html.twig
+++ b/templates/provider/show_field_mappings_tab.html.twig
@@ -156,4 +156,4 @@
 })();
 </script>
 
-<script type="text/javascript" src="{{ call(['GlpiPlugin\\Singlesignon\\ToolboxPlugin', 'getPublicAssetUrl'], ['js/mapping-row-actions.js']) }}"></script>
+<script type="text/javascript" src="{{ get_plugin_web_dir('singlesignon') }}/public/js/mapping-row-actions.js"></script>

--- a/templates/provider/show_role_mappings_tab.html.twig
+++ b/templates/provider/show_role_mappings_tab.html.twig
@@ -141,4 +141,4 @@
 })();
 </script>
 
-<script type="text/javascript" src="{{ call(['GlpiPlugin\\Singlesignon\\ToolboxPlugin', 'getPublicAssetUrl'], ['js/mapping-row-actions.js']) }}"></script>
+<script type="text/javascript" src="{{ get_plugin_web_dir('singlesignon') }}/public/js/mapping-row-actions.js"></script>


### PR DESCRIPTION
## Description
This PR addresses a critical rendering issue in GLPI 11 where accessing the SSO plugin's configuration tabs triggers an `Invalid callable` error, crashing the page. 

Previously, we loaded our JavaScript assets using an inline Twig call:
`{{ call(['GlpiPlugin\\Singlesignon\\ToolboxPlugin', 'getPublicAssetUrl'], ['...']) }}`

While this array syntax is perfectly valid in PHP 8.2+, it fails in GLPI 11's Twig rendering context. GLPI 11's `PhpExtension.php` verifies Twig functions using a strict `!is_callable($callable)` check. Because the plugin's internal namespace is not fully exposed to the autoloader during the exact moment Twig evaluates this sandbox context, `is_callable()` incorrectly returns `false`. GLPI then manually extracts the array into a `Class::method()` string and triggers a fatal `E_USER_WARNING`.

```
glpi.WARNING:   *** User Warning: Invalid callable `GlpiPlugin\Singlesignon\ToolboxPlugin::getPublicAssetUrl()`. at PhpExtension.php line 101
  Backtrace :
  ...Application/View/Extension/PhpExtension.php:101 
  ...tes/c3/c36a4fc86ef48eb75e7564bd3d8d75f3.php:309 Glpi\Application\View\Extension\PhpExtension->call()
  ./vendor/twig/twig/src/Template.php:402            __TwigTemplate_822cc2285d2355911284129fcd4f36ac->doDisplay()
  ./vendor/twig/twig/src/Template.php:358            Twig\Template->yield()
  ./vendor/twig/twig/src/Template.php:373            Twig\Template->display()
  ./vendor/twig/twig/src/TemplateWrapper.php:51      Twig\Template->render()
  .../Glpi/Application/View/TemplateRenderer.php:170 Twig\TemplateWrapper->render()
  ./plugins/singlesignon/src/Provider_Field.php:181  Glpi\Application\View\TemplateRenderer->render()
  ./plugins/singlesignon/src/Provider_Field.php:159  GlpiPlugin\Singlesignon\Provider_Field->showProviderTab()
  ./src/CommonGLPI.php:717                           GlpiPlugin\Singlesignon\Provider_Field::displayTabContentForItem()
  ./ajax/common.tabs.php:108                         CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```

## Resolution
Instead of using complex `call()` workarounds or injecting variables from PHP controllers, this PR refactors the asset loading to use GLPI's native, highly efficient Twig function specifically designed for this:
`{{ get_plugin_web_dir('singlesignon') }}/public/js/mapping-row-actions.js`

We completely avoid the autoloader race condition while safely generating the correct `public/` paths for our JS assets. As a result, the `getPublicAssetUrl` function has been safely removed from `ToolboxPlugin.php` to clean up the codebase.

## Changes
* Removed `getPublicAssetUrl` from `ToolboxPlugin.php`.
* Replaced `call(...)` in `show_field_mappings_tab.html.twig` with `get_plugin_web_dir()`.
* Replaced `call(...)` in `show_role_mappings_tab.html.twig` with `get_plugin_web_dir()`.
* Replaced `call(...)` in `callback_test_result.html.twig` with `get_plugin_web_dir()`.